### PR TITLE
Fix API key environmental variable documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -32,5 +32,5 @@ resource "ns1_zone" "foobar" {
 The following arguments are supported:
 
 * `apikey` - (Required) NS1 API token. It must be provided, but it can also
-  be sourced from the `NS1_API_KEY` environment variable.
+  be sourced from the `NS1_APIKEY` environment variable.
 


### PR DESCRIPTION
The current documentation provides the wrong env variable. It's not NS1_API_KEY, but NS1_APIKEY. Terraform kept asking me for the API despite having set it in my environment:

```
❯ terraform plan
provider.ns1.apikey
  The ns1 API key, this is required

  Enter a value:
```
After searching through the source code and finding the correct key, it was working.