### PR TITLE
Fix typo in provider documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -32,5 +32,5 @@ resource "ns1_zone" "foobar" {
 The following arguments are supported:
 
 * `apikey` - (Required) NS1 API token. It must be provided, but it can also
-  be sourced from the `NS1_API_KEY` environment variable.
+  be sourced from the `NS1_APIKEY` environment variable.
 


### PR DESCRIPTION
Fixes a typo in the documentation of the NS1_APIKEY environment variable name.