### PR TITLE
Usernames cannot be changed in NS1 so must force new

### DIFF
--- a/ns1/resource_user.go
+++ b/ns1/resource_user.go
@@ -20,6 +20,7 @@ func userResource() *schema.Resource {
 		"username": {
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		"email": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
The current state of the provider is to just attempt to update the username when it is changed. This results in the error, `500 We found a problem processing this request. Please contact support.` To fix this, require a destroy and create for the user if the username is to be updated.