### PR TITLE
Make 'networks' field computed for zone resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.2.0 (Unreleased)
+## 1.1.1 (Unreleased)
+
+BUG FIXES:
+
+* resource/zone: Make `networks` field computed
+
 ## 1.1.0 (January 08, 2019)
 
 * Add support for short_answers in record resources

--- a/ns1/resource_zone.go
+++ b/ns1/resource_zone.go
@@ -74,6 +74,7 @@ func zoneResource() *schema.Resource {
 			"networks": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
 		},


### PR DESCRIPTION
The NS1 API does not require the networks field and provides a sane default. Currently when a user does not specify a value in their config, terraform always shows this as a difference. To fix this undesirable behavior, this patch makes the field computed. This change should be backwards compatible for existing users.