### PR TITLE
Don't try to convert filter config values to ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.1.2 (Unreleased)
+
+BUG FIXES:
+
+* resource/record: Don't try to convert config values to ints
+
 ## 1.1.1 (February 01, 2019)
 
 BUG FIXES:

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/fatih/structs"
@@ -336,13 +335,7 @@ func resourceDataToRecord(r *dns.Record, d *schema.ResourceData) error {
 				f.Disabled = disabled.(bool)
 			}
 			if rawConfig, ok := fi["config"]; ok {
-				for k, v := range rawConfig.(map[string]interface{}) {
-					if i, err := strconv.Atoi(v.(string)); err == nil {
-						f.Config[k] = i
-					} else {
-						f.Config[k] = v
-					}
-				}
+				f.Config = rawConfig.(map[string]interface{})
 			}
 			filters[i] = &f
 		}


### PR DESCRIPTION
This behavior was preventing customers from being able to specify a boolean value, which is needed for a number of filter configs. This change should be backwards compatible because our API will accept strings of digits wherever an int is called for.