### PR TITLE
Sort regions inside Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Due to some limitations in Terraform's support of nested maplike objects,
 there are some irregularities in supporting metadata, however metadata is
 now supported at every level.
 
+Note that regions should be sorted by name in the record's regions list,
+otherwise terraform will detect changes to the record when none actually exist.
+
 A record _requires_ a [Zone](#zone)
 
 _Example_
@@ -284,7 +287,7 @@ resource "ns1_user" "u" {
   name = "terraform acc test user %s"
   username = "tf_acc_test_user_%s"
   email = "tf_acc_test_ns1@hashicorp.com"
-  
+
   #optional
   teams = ["${ns1_team.t.id}"]
   notify {

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -349,35 +349,24 @@ func resourceDataToRecord(r *dns.Record, d *schema.ResourceData) error {
 		r.Filters = filters
 	}
 	if regions := d.Get("regions").([]interface{}); len(regions) > 0 {
-		keys := make([]string, 0, len(regions))
 		for _, regionRaw := range regions {
 			region := regionRaw.(map[string]interface{})
-			keys = append(keys, region["name"].(string))
-		}
-		sort.Strings(keys)
+			ns1R := data.Region{
+				Meta: data.Meta{},
+			}
 
-		for _, k := range keys {
-			for _, regionRaw := range regions {
-				region := regionRaw.(map[string]interface{})
-				if region["name"].(string) == k {
-					ns1R := data.Region{
-						Meta: data.Meta{},
-					}
-
-					if v, ok := region["meta"]; ok {
-						log.Println("region meta", v)
-						meta := data.MetaFromMap(v.(map[string]interface{}))
-						log.Println("region meta object", meta)
-						ns1R.Meta = *meta
-						log.Println(ns1R.Meta)
-						errs := ns1R.Meta.Validate()
-						if len(errs) > 0 {
-							return errJoin(append([]error{errors.New("found error/s in region/group metadata")}, errs...), ",")
-						}
-					}
-					r.Regions[region["name"].(string)] = ns1R
+			if v, ok := region["meta"]; ok {
+				log.Println("region meta", v)
+				meta := data.MetaFromMap(v.(map[string]interface{}))
+				log.Println("region meta object", meta)
+				ns1R.Meta = *meta
+				log.Println(ns1R.Meta)
+				errs := ns1R.Meta.Validate()
+				if len(errs) > 0 {
+					return errJoin(append([]error{errors.New("found error/s in region/group metadata")}, errs...), ",")
 				}
 			}
+			r.Regions[region["name"].(string)] = ns1R
 		}
 	}
 	return nil

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -315,17 +315,17 @@ resource "ns1_record" "it" {
     // }
   }
 
+	regions {
+    name = "ny"
+    // meta {
+    //   us_state = ["NY"]
+    // }
+  }
+	
   regions {
     name = "wa"
     // meta {
     //   us_state = ["WA"]
-    // }
-  }
-
-  regions {
-    name = "ny"
-    // meta {
-    //   us_state = ["NY"]
     // }
   }
 


### PR DESCRIPTION
To partially address #19, force a deterministic ordering of the regions in a record.  I say partially, because this assumes the regions in the terraform template are already sorted.
