### PR TITLE
Update acceptance tests for Terraform 0.12 compatability

### DIFF
--- a/ns1/resource_datafeed_test.go
+++ b/ns1/resource_datafeed_test.go
@@ -150,7 +150,7 @@ resource "ns1_datasource" "api" {
 resource "ns1_datafeed" "foobar" {
   name = "terraform test"
   source_id = "${ns1_datasource.api.id}"
-  config {
+  config = {
     label = "exampledc2"
   }
 }`
@@ -164,7 +164,7 @@ resource "ns1_datasource" "api" {
 resource "ns1_datafeed" "foobar" {
   name = "terraform test"
   source_id = "${ns1_datasource.api.id}"
-  config {
+  config = {
     label = "exampledc3"
   }
 }`

--- a/ns1/resource_monitoringjob_test.go
+++ b/ns1/resource_monitoringjob_test.go
@@ -292,7 +292,7 @@ resource "ns1_monitoringjob" "it" {
     port = 443
     host = "1.2.3.4"
   }
-  rules = {
+  rules {
     value = "200 OK"
     comparison = "contains"
     key = "output"
@@ -317,7 +317,7 @@ resource "ns1_monitoringjob" "it" {
     port = 443
     host = "1.1.1.1"
   }
-  rules = {
+  rules {
     value = 200
     comparison = "<="
     key = "connect"

--- a/ns1/resource_notifylist_test.go
+++ b/ns1/resource_notifylist_test.go
@@ -136,7 +136,7 @@ func testAccCheckNotifyListName(nl *monitor.NotifyList, expected string) resourc
 const testAccNotifyListBasic = `
 resource "ns1_notifylist" "test" {
   name = "terraform test"
-  notifications = {
+  notifications {
     type = "webhook"
     config = {
       url = "http://localhost:9090"
@@ -148,7 +148,7 @@ resource "ns1_notifylist" "test" {
 const testAccNotifyListUpdated = `
 resource "ns1_notifylist" "test" {
   name = "terraform test"
-  notifications = {
+  notifications {
     type = "webhook"
     config = {
       url = "http://localhost:9091"

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -243,7 +243,7 @@ func testAccCheckRecordAnswerRdata(r *dns.Record, idx int, expected string) reso
 
 const testAccRecordBasic = `
 resource "ns1_record" "it" {
-  zone              = "${ns1_zone.test.zone}"
+  zone              = ns1_zone.test.zone
   domain            = "test.${ns1_zone.test.zone}"
   type              = "CNAME"
   ttl               = 60
@@ -350,7 +350,7 @@ resource "ns1_record" "spf" {
   type              = "SPF"
   ttl               = 86400
   use_client_subnet = "true"
-  answers = {
+  answers {
     answer = "v=DKIM1; k=rsa; p=XXXXXXXX"
   }
 }

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -94,7 +94,7 @@ resource "ns1_user" "u" {
   username = "tf_acc_test_user_%s"
   email = "tf_acc_test_ns1@hashicorp.com"
   teams = ["${ns1_team.t.id}"]
-  notify {
+  notify = {
   	billing = true
   }
 }


### PR DESCRIPTION
Updates schema of Terraform configs in acceptance tests for compatibility with Terraform v0.12.  Output of `make testacc` with provider compiled against `terraform@v0.12.0-beta1`
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-ns1   [no test files]
=== RUN   TestAccDataSourceZone_basic
--- PASS: TestAccDataSourceZone_basic (7.12s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDataFeed_basic
--- PASS: TestAccDataFeed_basic (10.86s)
=== RUN   TestAccDataFeed_updated
--- PASS: TestAccDataFeed_updated (13.66s)
=== RUN   TestAccDataSource_basic
--- PASS: TestAccDataSource_basic (5.35s)
=== RUN   TestAccDataSource_updated
--- PASS: TestAccDataSource_updated (11.30s)
=== RUN   TestAccMonitoringJob_basic
--- PASS: TestAccMonitoringJob_basic (5.55s)
=== RUN   TestAccMonitoringJob_updated
--- PASS: TestAccMonitoringJob_updated (8.25s)
=== RUN   TestAccNotifyList_basic
--- PASS: TestAccNotifyList_basic (5.49s)
=== RUN   TestAccNotifyList_updated
--- PASS: TestAccNotifyList_updated (9.35s)
=== RUN   TestAccRecord_basic
--- PASS: TestAccRecord_basic (15.21s)
=== RUN   TestAccRecord_updated
--- PASS: TestAccRecord_updated (15.77s)
=== RUN   TestAccRecord_SPF
--- PASS: TestAccRecord_SPF (14.05s)
=== RUN   TestAccRecord_SRV
--- PASS: TestAccRecord_SRV (12.93s)
=== RUN   TestAccTeam_basic
--- PASS: TestAccTeam_basic (6.85s)
=== RUN   TestAccTeam_updated
--- PASS: TestAccTeam_updated (10.48s)
=== RUN   TestAccUser_basic
--- PASS: TestAccUser_basic (12.65s)
=== RUN   TestAccZone_basic
--- PASS: TestAccZone_basic (8.46s)
=== RUN   TestAccZone_updated
--- PASS: TestAccZone_updated (10.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-ns1/ns1       183.883s
```