### PR TITLE
Update ns1-go dependency to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
 	golang.org/x/sys v0.0.0-20190222171317-cd391775e71e // indirect
 	golang.org/x/text v0.3.0 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.0.0-20190322154155-0dafb5275fd1
+	gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790
 )

--- a/go.sum
+++ b/go.sum
@@ -278,5 +278,7 @@ gopkg.in/ns1/ns1-go.v2 v2.0.0-20180709153726-85a531ec65f1 h1:oI06FzeavrGiypycDSG
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20180709153726-85a531ec65f1/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190322154155-0dafb5275fd1 h1:+fgY/3ngqdBW9oLQCMwL5g+QRkKFPJH05fx2/pipqRQ=
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190322154155-0dafb5275fd1/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790 h1:uKxXHnbIJUsvNr+8rlG4kuwKkSKhWN4tiqaAljJtq84=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e h1:o/mfNjxpTLivuKEfxzzwrJ8PmulH2wEp7t713uMwKAA=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -221,7 +221,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/transport
-# gopkg.in/ns1/ns1-go.v2 v2.0.0-20190322154155-0dafb5275fd1
+# gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790
 gopkg.in/ns1/ns1-go.v2/rest
 gopkg.in/ns1/ns1-go.v2/rest/model/account
 gopkg.in/ns1/ns1-go.v2/rest/model/data


### PR DESCRIPTION
Updates ns1-go module to latest version.

This integrates bugfixes to allow for resolution of #53 when assigning the value of a key in a meta block to the raw JSON string of a feed (i.e. `weight = "{\"feed\":\"${ns1_datafeed.foobar.id}\"}"`).

This workaround can also be used to resolve #35 until Terraform 0.12 is released and enhanced support for nested data structures make their way into the SDK, at which point a refactor of our schema will be required.