### PR TITLE
Fix IP Prefixes validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+*.vscode
 
 website/vendor
 

--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,5 @@ require (
 	github.com/terraform-providers/terraform-provider-aws v1.29.0 // indirect
 	github.com/terraform-providers/terraform-provider-template v1.0.0 // indirect
 	github.com/terraform-providers/terraform-provider-tls v1.2.0 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790
+	gopkg.in/ns1/ns1-go.v2 v2.0.0-20190703192230-737a440630af
 )

--- a/go.sum
+++ b/go.sum
@@ -630,6 +630,8 @@ gopkg.in/ns1/ns1-go.v2 v2.0.0-20190322154155-0dafb5275fd1 h1:+fgY/3ngqdBW9oLQCMw
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190322154155-0dafb5275fd1/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790 h1:uKxXHnbIJUsvNr+8rlG4kuwKkSKhWN4tiqaAljJtq84=
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20190703192230-737a440630af h1:UWJyT9JTyCk+Buwf8L7VmypPqj/REgN74ruoZW5jCqU=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20190703192230-737a440630af/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e h1:o/mfNjxpTLivuKEfxzzwrJ8PmulH2wEp7t713uMwKAA=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -259,7 +259,6 @@ func testAccCheckRecordAnswerMetaIPPrefixes(r *dns.Record, expected []string) re
 		recordAnswer := r.Answers[0]
 		recordMetas := recordAnswer.Meta
 		ipPrefixes := make([]string, len(recordMetas.IPPrefixes.([]interface{})))
-		//copy(ipPrefixes, recordMetas.IPPrefixes.([]string))
 		for i, v := range recordMetas.IPPrefixes.([]interface{}) {
 			ipPrefixes[i] = v.(string)
 		}

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
@@ -57,6 +57,7 @@ type Client struct {
 	Notifications *NotificationsService
 	Records       *RecordsService
 	Settings      *SettingsService
+	Stats         *StatsService
 	Teams         *TeamsService
 	Users         *UsersService
 	Warnings      *WarningsService
@@ -86,6 +87,7 @@ func NewClient(httpClient Doer, options ...func(*Client)) *Client {
 	c.Notifications = (*NotificationsService)(&c.common)
 	c.Records = (*RecordsService)(&c.common)
 	c.Settings = (*SettingsService)(&c.common)
+	c.Stats = (*StatsService)(&c.common)
 	c.Teams = (*TeamsService)(&c.common)
 	c.Users = (*UsersService)(&c.common)
 	c.Warnings = (*WarningsService)(&c.common)

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/data/meta.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/data/meta.go
@@ -291,15 +291,25 @@ func validateCidr(v reflect.Value) error {
 			return err
 		}
 	}
-	var last error
 	if v.Kind() == reflect.Slice {
+		if slc, ok := v.Interface().([]string); ok {
+			for _, s := range slc {
+				_, _, err := net.ParseCIDR(s)
+				if err != nil {
+					return fmt.Errorf("%s is not a valid CIDR block", s)
+				}
+			}
+			return nil
+		}
 		slc := v.Interface().([]interface{})
 		for _, s := range slc {
 			_, _, err := net.ParseCIDR(s.(string))
-			last = err
+			if err != nil {
+				return fmt.Errorf("%s is not a valid CIDR block", s.(string))
+			}
 		}
 	}
-	return last
+	return nil
 }
 
 // validatePositiveNumber makes sure that the given number (float or int) is positive

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/stat.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/stat.go
@@ -1,15 +1,63 @@
 package rest
 
-// // GetQPSStats returns current queries per second (QPS) for the account
-// func (c APIClient) GetQPSStats() (v float64, err error) {
-// 	var s map[string]float64
-// 	_, err = c.doHTTPUnmarshal("GET", "https://api.nsone.net/v1/stats/qps", nil, &s)
-// 	if err != nil {
-// 		return v, err
-// 	}
-// 	v, found := s["qps"]
-// 	if !found {
-// 		return v, errors.New("Could not find 'qps' key in returned data")
-// 	}
-// 	return v, nil
-// }
+import (
+	"fmt"
+	"net/http"
+)
+
+const statsQPSEndpoint = "stats/qps"
+
+// StatsService handles 'stats/qps' endpoint.
+type StatsService service
+
+// GetQPS returns current queries per second (QPS) for the account.
+// The QPS number is lagged by approximately 30 seconds for statistics collection;
+// and the rate is computed over the preceding minute.
+func (s *StatsService) GetQPS() (float32, *http.Response, error) {
+	return s.getQPS(statsQPSEndpoint)
+}
+
+// GetZoneQPS returns current queries per second (QPS) for a specific zone.
+// The QPS number is lagged by approximately 30 seconds for statistics collection;
+// and the rate is computed over the preceding minute.
+func (s *StatsService) GetZoneQPS(zone string) (float32, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s", statsQPSEndpoint, zone)
+	return s.getQPS(path)
+}
+
+// GetRecordQPS returns current queries per second (QPS) for a specific record.
+// The QPS number is lagged by approximately 30 seconds for statistics collection;
+// and the rate is computed over the preceding minute.
+func (s *StatsService) GetRecordQPS(zone, record, t string) (float32, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s/%s/%s", statsQPSEndpoint, zone, record, t)
+	return s.getQPS(path)
+}
+
+func (s *StatsService) getQPS(path string) (float32, *http.Response, error) {
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var r map[string]float32
+	resp, err := s.client.Do(req, &r)
+
+	if err != nil {
+		switch err.(type) {
+		case *Error:
+			switch err.(*Error).Message {
+			case "zone not found":
+				return 0, nil, ErrZoneMissing
+			case "record not found":
+				return 0, nil, ErrRecordMissing
+			}
+		}
+		return 0, nil, err
+	}
+
+	qps, ok := r["qps"]
+	if !ok {
+		return 0, nil, fmt.Errorf("could not find 'qps' key in returned data: %v", resp)
+	}
+	return qps, resp, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -294,7 +294,7 @@ google.golang.org/grpc/credentials/internal
 google.golang.org/grpc/balancer/base
 google.golang.org/grpc/binarylog/grpc_binarylog_v1
 google.golang.org/grpc/internal/syscall
-# gopkg.in/ns1/ns1-go.v2 v2.0.0-20190430170845-6c599e5e5790
+# gopkg.in/ns1/ns1-go.v2 v2.0.0-20190703192230-737a440630af
 gopkg.in/ns1/ns1-go.v2/rest
 gopkg.in/ns1/ns1-go.v2/rest/model/account
 gopkg.in/ns1/ns1-go.v2/rest/model/data


### PR DESCRIPTION
* Update ns1-go dependency to fix crash when passing multiple `ip_prefixes` as a comma delimited string
* Add test for attributes in record meta block to verify `ip_prefixes` fix works as intended