### PR TITLE
Extended Notification Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.5.0 (Unreleased)
+
+FEATURES:
+
+* resource/notifylist: Adds support for all notifier types currently supported by SDK.  Returns error on unsupported notifier type. [#59](https://github.com/terraform-providers/terraform-provider-ns1/pull/59)
+
 ## 1.4.1 (July 04, 2019)
 
 IMPROVEMENTS:

--- a/ns1/resource_notifylist.go
+++ b/ns1/resource_notifylist.go
@@ -1,6 +1,7 @@
 package ns1
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
@@ -67,12 +68,22 @@ func resourceDataToNotifyList(nl *monitor.NotifyList, d *schema.ResourceData) er
 			config := ni["config"].(map[string]interface{})
 
 			switch ni["type"].(string) {
-			case "webhook":
-				ns[i] = monitor.NewWebNotification(config["url"].(string))
+			case "user":
+				ns[i] = monitor.NewUserNotification(config["user"].(string))
 			case "email":
 				ns[i] = monitor.NewEmailNotification(config["email"].(string))
 			case "datafeed":
 				ns[i] = monitor.NewFeedNotification(config["sourceid"].(string))
+			case "webhook":
+				ns[i] = monitor.NewWebNotification(config["url"].(string))
+			case "pagerduty":
+				ns[i] = monitor.NewPagerDutyNotification(config["service_key"].(string))
+			case "hipchat":
+				ns[i] = monitor.NewHipChatNotification(config["token"].(string), config["room"].(string))
+			case "slack":
+				ns[i] = monitor.NewSlackNotification(config["url"].(string), config["username"].(string), config["channel"].(string))
+			default:
+				return fmt.Errorf("%s is not a valid notifier type", ni["type"])
 			}
 		}
 		nl.Notifications = ns


### PR DESCRIPTION
Adds support and tests for all notifier types supported by NS1 SDK.  Returns error on unsupported notifier type.  Resolves #34 