### PR TITLE
randomize zone name in acc tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 1.5.2 (Unreleased)
+
+IMPROVEMENTS:
+
+* acc tests: Randomize zone names to help prevent collisions
+
 ## 1.5.1 (August 30, 2019)
+
+IMPROVEMENTS:
 
 * General Documentation updates: Flesh out examples and attributes across the board. ([#62](https://github.com/terraform-providers/terraform-provider-ns1/issues/62))
 * Add known issues/roadmap section to main README ([#62](https://github.com/terraform-providers/terraform-provider-ns1/issues/62))

--- a/ns1/data_source_zone_test.go
+++ b/ns1/data_source_zone_test.go
@@ -1,8 +1,10 @@
 package ns1
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
@@ -11,16 +13,20 @@ import (
 func TestAccDataSourceZone_basic(t *testing.T) {
 	var zone dns.Zone
 	dataSourceName := "data.ns1_zone.test"
+	zoneName := fmt.Sprintf(
+		"terraform-test-%s.io",
+		acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum),
+	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceZoneBasic,
+				Config: testAccDataSourceZoneBasic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists(dataSourceName, &zone),
-					resource.TestCheckResourceAttr(dataSourceName, "zone", "terraform-testda-zone.io"),
+					resource.TestCheckResourceAttr(dataSourceName, "zone", zoneName),
 					resource.TestCheckResourceAttr(dataSourceName, "ttl", "3600"),
 					resource.TestCheckResourceAttr(dataSourceName, "refresh", "43200"),
 					resource.TestCheckResourceAttr(dataSourceName, "retry", "7200"),
@@ -35,9 +41,9 @@ func TestAccDataSourceZone_basic(t *testing.T) {
 	})
 }
 
-const testAccDataSourceZoneBasic = `
-resource "ns1_zone" "it" {
-  zone = "terraform-testda-zone.io"
+func testAccDataSourceZoneBasic(zoneName string) string {
+	return fmt.Sprintf(`resource "ns1_zone" "it" {
+  zone = "%s"
   primary = "1.1.1.1"
   additional_primaries = ["2.2.2.2", "3.3.3.3"]
 }
@@ -45,4 +51,5 @@ resource "ns1_zone" "it" {
 data "ns1_zone" "test" {
   zone = "${ns1_zone.it.zone}"
 }
-`
+`, zoneName)
+}

--- a/ns1/resource_zone.go
+++ b/ns1/resource_zone.go
@@ -180,7 +180,7 @@ func resourceZoneRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-// resourceZoneDelete deteles the given zone from ns1
+// resourceZoneDelete deletes the given zone from ns1
 func resourceZoneDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ns1.Client)
 	_, err := client.Zones.Delete(d.Get("zone").(string))

--- a/ns1/resource_zone_test.go
+++ b/ns1/resource_zone_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -13,16 +14,20 @@ import (
 
 func TestAccZone_basic(t *testing.T) {
 	var zone dns.Zone
+	zoneName := fmt.Sprintf(
+		"terraform-test-%s.io",
+		acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum),
+	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneBasic,
+				Config: testAccZoneBasic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("ns1_zone.it", &zone),
-					testAccCheckZoneName(&zone, "terraform-test-zone.io"),
+					testAccCheckZoneName(&zone, zoneName),
 					testAccCheckZoneTTL(&zone, 3600),
 					testAccCheckZoneRefresh(&zone, 43200),
 					testAccCheckZoneRetry(&zone, 7200),
@@ -36,16 +41,20 @@ func TestAccZone_basic(t *testing.T) {
 
 func TestAccZone_updated(t *testing.T) {
 	var zone dns.Zone
+	zoneName := fmt.Sprintf(
+		"terraform-test-%s.io",
+		acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum),
+	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneBasic,
+				Config: testAccZoneBasic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("ns1_zone.it", &zone),
-					testAccCheckZoneName(&zone, "terraform-test-zone.io"),
+					testAccCheckZoneName(&zone, zoneName),
 					testAccCheckZoneTTL(&zone, 3600),
 					testAccCheckZoneRefresh(&zone, 43200),
 					testAccCheckZoneRetry(&zone, 7200),
@@ -54,10 +63,10 @@ func TestAccZone_updated(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccZoneUpdated,
+				Config: testAccZoneUpdated(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("ns1_zone.it", &zone),
-					testAccCheckZoneName(&zone, "terraform-test-zone.io"),
+					testAccCheckZoneName(&zone, zoneName),
 					testAccCheckZoneTTL(&zone, 10800),
 					testAccCheckZoneRefresh(&zone, 3600),
 					testAccCheckZoneRetry(&zone, 300),
@@ -71,6 +80,10 @@ func TestAccZone_updated(t *testing.T) {
 
 func TestAccZone_secondary(t *testing.T) {
 	var zone dns.Zone
+	zoneName := fmt.Sprintf(
+		"terraform-test-%s.io",
+		acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum),
+	)
 	expectedOtherPorts := []int{53, 53}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,10 +91,10 @@ func TestAccZone_secondary(t *testing.T) {
 		CheckDestroy: testAccCheckZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZonePrimary,
+				Config: testAccZonePrimary(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneExists("ns1_zone.it", &zone),
-					testAccCheckZoneName(&zone, "terraform-test-zone.io"),
+					testAccCheckZoneName(&zone, zoneName),
 					resource.TestCheckResourceAttr("ns1_zone.it", "primary", "1.1.1.1"),
 					resource.TestCheckResourceAttr("ns1_zone.it", "additional_primaries.0", "2.2.2.2"),
 					resource.TestCheckResourceAttr("ns1_zone.it", "additional_primaries.1", "3.3.3.3"),
@@ -206,15 +219,17 @@ func testAccCheckOtherPorts(zone *dns.Zone, expected []int) resource.TestCheckFu
 	}
 }
 
-const testAccZoneBasic = `
-resource "ns1_zone" "it" {
-  zone = "terraform-test-zone.io"
+func testAccZoneBasic(zoneName string) string {
+	return fmt.Sprintf(`resource "ns1_zone" "it" {
+  zone = "%s"
 }
-`
+`, zoneName)
+}
 
-const testAccZoneUpdated = `
+func testAccZoneUpdated(zoneName string) string {
+	return fmt.Sprintf(`
 resource "ns1_zone" "it" {
-  zone    = "terraform-test-zone.io"
+  zone    = "%s"
   ttl     = 10800
   refresh = 3600
   retry   = 300
@@ -223,11 +238,12 @@ resource "ns1_zone" "it" {
   # link    = "1.2.3.4.in-addr.arpa" # TODO
   # primary = "1.2.3.4.in-addr.arpa" # TODO
 }
-`
+`, zoneName)
+}
 
-const testAccZonePrimary = `
-resource "ns1_zone" "it" {
-  zone    = "terraform-test-zone.io"
+func testAccZonePrimary(zoneName string) string {
+	return fmt.Sprintf(`resource "ns1_zone" "it" {
+  zone    = "%s"
   ttl     = 10800
   refresh = 3600
   retry   = 300
@@ -236,4 +252,5 @@ resource "ns1_zone" "it" {
   primary = "1.1.1.1"
   additional_primaries = ["2.2.2.2", "3.3.3.3"]
 }
-`
+`, zoneName)
+}


### PR DESCRIPTION
Help prevent collisions, since zone names need to be unique

Bonus: typo fix