### PR TITLE
Record: ignore the order of the locations provided in the regions blocks

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -109,8 +109,9 @@ func recordResource() *schema.Resource {
 							Required: true,
 						},
 						"meta": {
-							Type:     schema.TypeMap,
-							Optional: true,
+							Type:             schema.TypeMap,
+							Optional:         true,
+							DiffSuppressFunc: regionsMetaDiffSuppress,
 						},
 					},
 				},
@@ -424,4 +425,29 @@ func RecordStateFunc(d *schema.ResourceData, meta interface{}) ([]*schema.Resour
 	d.Set("type", parts[2])
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func regionsMetaDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if strings.HasSuffix(k, ".georegion") ||
+		strings.HasSuffix(k, ".country") ||
+		strings.HasSuffix(k, ".us_state") ||
+		strings.HasSuffix(k, ".ca_province") {
+
+		compare_map := make(map[string]bool)
+		for _, value := range strings.Split(old, ",") {
+			compare_map[strings.TrimSpace(value)] = true
+		}
+		for _, value := range strings.Split(new, ",") {
+			value = strings.TrimSpace(value)
+			if _, ok := compare_map[value]; ok {
+				delete(compare_map, value)
+			} else {
+				return false
+			}
+		}
+
+		return len(compare_map) == 0
+	}
+
+	return false
 }


### PR DESCRIPTION
The list of locations provided in the meta of the regions block were
depending on a specific order that was difficult to reproduce, leading
to having the terraform provider finding differences where there was
not any.

This fixes it by comparing the contents of the 'georegion', 'country',
'us_state' and 'ca_province' meta by first splitting the values on
commas, and verifying that they both contain the same elements.