### PR TITLE
INT-43 support toggling DNSSEC on zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 $ make testacc
 ```
 
+Some helpful things for debugging:
+
+* Set `TF_LOG=DEBUG` for verbose logging.
+* Additionally set `NS1_DEBUG` environment variable to include details of the
+  API requests in the logs.
+
 Known Issues/Roadmap
 --------------------
 

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,11 @@ require (
 	github.com/satori/uuid v0.0.0-20160927100844-b061729afc07 // indirect
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/terraform-providers/terraform-provider-aws v1.29.0 // indirect
 	github.com/terraform-providers/terraform-provider-template v1.0.0 // indirect
 	github.com/terraform-providers/terraform-provider-tls v1.2.0 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.0.0-20190730140822-b51389932cbc
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/ns1/ns1-go.v2 v2.0.0-20190927162648-9d01ca2a3b6d
 )

--- a/go.sum
+++ b/go.sum
@@ -502,6 +502,7 @@ github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -657,6 +658,7 @@ google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
@@ -672,6 +674,8 @@ gopkg.in/ns1/ns1-go.v2 v2.0.0-20190703192230-737a440630af h1:UWJyT9JTyCk+Buwf8L7
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190703192230-737a440630af/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190730140822-b51389932cbc h1:GAcf+t0o8gdJAdSFYdE9wChu4bIyguMVqz0RHiFL5VY=
 gopkg.in/ns1/ns1-go.v2 v2.0.0-20190730140822-b51389932cbc/go.mod h1:VV+3haRsgDiVLxyifmMBrBIuCWFBPYKbRssXB9z67Hw=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20190927162648-9d01ca2a3b6d h1:HbTWV3TEO+WExDngqmJWbTsgIF35BC/kJfnUkdrUie8=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20190927162648-9d01ca2a3b6d/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e h1:o/mfNjxpTLivuKEfxzzwrJ8PmulH2wEp7t713uMwKAA=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/ns1/data_source_zone.go
+++ b/ns1/data_source_zone.go
@@ -90,6 +90,10 @@ func dataSourceZone() *schema.Resource {
 					},
 				},
 			},
+			"dnssec": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 		Read: dataSourceZoneRead,
 	}
@@ -104,6 +108,7 @@ func dataSourceZoneToResourceData(d *schema.ResourceData, z *dns.Zone) error {
 	d.Set("retry", z.Retry)
 	d.Set("expiry", z.Expiry)
 	d.Set("networks", z.NetworkIDs)
+	d.Set("dnssec", z.DNSSEC)
 	d.Set("dns_servers", strings.Join(z.DNSServers[:], ","))
 	d.Set("link", z.Link)
 	if z.Secondary != nil && z.Secondary.Enabled {

--- a/ns1/resource_zone.go
+++ b/ns1/resource_zone.go
@@ -115,6 +115,11 @@ func resourceZone() *schema.Resource {
 					},
 				},
 			},
+			"dnssec": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 		},
 		Create:   resourceZoneCreate,
 		Read:     resourceZoneRead,
@@ -133,6 +138,9 @@ func resourceZoneToResourceData(d *schema.ResourceData, z *dns.Zone) error {
 	d.Set("retry", z.Retry)
 	d.Set("expiry", z.Expiry)
 	d.Set("networks", z.NetworkIDs)
+	if z.DNSSEC != nil {
+		d.Set("dnssec", *z.DNSSEC)
+	}
 	d.Set("dns_servers", strings.Join(z.DNSServers[:], ","))
 	if z.Secondary != nil && z.Secondary.Enabled {
 		d.Set("primary", z.Secondary.PrimaryIP)
@@ -185,6 +193,12 @@ func resourceToZoneData(z *dns.Zone, d *schema.ResourceData) {
 	}
 	if v, ok := d.GetOk("primary"); ok {
 		z.MakeSecondary(v.(string))
+	}
+	if v, ok := d.GetOkExists("dnssec"); ok {
+		if v != nil {
+			dnssec := v.(bool)
+			z.DNSSEC = &dnssec
+		}
 	}
 	if v, ok := d.GetOk("additional_primaries"); ok {
 		otherIPsRaw := v.([]interface{})

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
@@ -62,6 +62,7 @@ type Client struct {
 	Users         *UsersService
 	Warnings      *WarningsService
 	Zones         *ZonesService
+	DNSSEC        *DNSSECService
 }
 
 // NewClient constructs and returns a reference to an instantiated Client.
@@ -92,6 +93,7 @@ func NewClient(httpClient Doer, options ...func(*Client)) *Client {
 	c.Users = (*UsersService)(&c.common)
 	c.Warnings = (*WarningsService)(&c.common)
 	c.Zones = (*ZonesService)(&c.common)
+	c.DNSSEC = (*DNSSECService)(&c.common)
 
 	for _, option := range options {
 		option(c)

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/dnssec.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/dnssec.go
@@ -1,0 +1,48 @@
+package rest
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+// DNSSECService handles 'zones/ZONE/dnssec' endpoint.
+type DNSSECService service
+
+// Get takes a zone, and returns DNSSEC information.
+//
+// NS1 API docs: https://ns1.com/api#get-get-dnssec-details-for-a-zone
+func (s *DNSSECService) Get(zone string) (*dns.ZoneDNSSEC, *http.Response, error) {
+	path := fmt.Sprintf("zones/%s/dnssec", zone)
+
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var d dns.ZoneDNSSEC
+	resp, err := s.client.Do(req, &d)
+
+	if err != nil {
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "zone not found" {
+				return nil, resp, ErrZoneMissing
+			}
+			if err.(*Error).Message == "DNSSEC is not enabled on the zone" {
+				return nil, resp, ErrDNSECNotEnabled
+			}
+		}
+		return nil, resp, err
+	}
+
+	return &d, resp, nil
+}
+
+var (
+	// ErrDNSECNotEnabled if DNSSEC is not enabled for the zone, regardless of
+	// account-level DNSSEC permission.
+	ErrDNSECNotEnabled = errors.New("DNSSEC is not enabled on the zone")
+)

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/dns/dnssec.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/dns/dnssec.go
@@ -1,0 +1,50 @@
+package dns
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ZoneDNSSEC wraps an NS1 /zone/{zone}/dnssec resource
+type ZoneDNSSEC struct {
+	Zone       string      `json:"zone,omitempty"`
+	Keys       *Keys       `json:"keys,omitempty"`
+	Delegation *Delegation `json:"delegation,omitempty"`
+}
+
+// Keys holds a list of DNS Keys and a TTL
+type Keys struct {
+	DNSKey  []*Key `json:"dnskey,omitempty"`
+	TTL     int    `json:"ttl,omitempty"`
+}
+
+// Delegation holds a list of DNS Keys, a list of DS Keys, and a TTL
+type Delegation struct {
+	DNSKey []*Key `json:"dnskey,omitempty"`
+	DS     []*Key `json:"ds,omitempty"`
+	TTL    int    `json:"ttl,omitempty"`
+}
+
+// Key holds a DNS key
+type Key struct {
+	Flags     string
+	Protocol  string
+	Algorithm string
+	PublicKey string
+}
+
+func (d ZoneDNSSEC) String() string {
+	return fmt.Sprintf("%s", d.Zone)
+}
+
+// UnmarshalJSON parses a Key from a list into a struct
+func (k *Key) UnmarshalJSON(buf []byte) error {
+	tmp := []interface{}{&k.Flags, &k.Protocol, &k.Algorithm, &k.PublicKey}
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if l := len(tmp); l != 4 {
+		return fmt.Errorf("wrong number of fields in Key: %d != 4", l)
+	}
+	return nil
+}

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/dns/zone.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/dns/zone.go
@@ -37,6 +37,10 @@ type Zone struct {
 	Primary *ZonePrimary `json:"primary,omitempty"`
 	// Secondary contains info for slaving the zone to a primary dns server.
 	Secondary *ZoneSecondary `json:"secondary,omitempty"`
+
+	// Whether or not DNSSEC is enabled on the zone. Note we use a pointer so
+	// leaving this unset will not change a previous setting.
+	DNSSEC *bool `json:"dnssec,omitempty"`
 }
 
 func (z Zone) String() string {
@@ -158,4 +162,5 @@ func (z *Zone) LinkTo(to string) {
 	z.Pool = ""
 	z.Secondary = nil
 	z.Link = &to
+	z.DNSSEC = nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -355,7 +355,7 @@ google.golang.org/grpc/credentials/internal
 google.golang.org/grpc/balancer/base
 google.golang.org/grpc/binarylog/grpc_binarylog_v1
 google.golang.org/grpc/internal/syscall
-# gopkg.in/ns1/ns1-go.v2 v2.0.0-20190730140822-b51389932cbc
+# gopkg.in/ns1/ns1-go.v2 v2.0.0-20190927162648-9d01ca2a3b6d
 gopkg.in/ns1/ns1-go.v2/rest
 gopkg.in/ns1/ns1-go.v2/rest/model/account
 gopkg.in/ns1/ns1-go.v2/rest/model/data

--- a/website/docs/d/zone.html.markdown
+++ b/website/docs/d/zone.html.markdown
@@ -37,6 +37,7 @@ In addition to the argument above, the following are exported:
 * `retry` - The SOA Retry.
 * `expiry` - The SOA Expiry.
 * `nx_ttl` - The SOA NX TTL.
+* `dnssec` - Whether or not DNSSEC is enabled for the zone.
 * `networks` - List of network IDs for which the zone is available.
 * `dns_servers` - Authoritative Name Servers.
 * `hostmaster` - The SOA Hostmaster.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,3 +37,12 @@ The following arguments are supported:
   be sourced from the `NS1_APIKEY` environment variable.
 * `version` - (Optional, but recommended if you don't like surprises) From
   output of `terraform init`.
+
+## Environment Variables
+
+The provider does check some environment variables:
+
+* `NS1_APIKEY` - (string) Explained above.
+* `NS1_ENDPOINT` - (string) For managed clients, this normally should not be set.
+* `NS1_IGNORE_SSL` - (boolean) This normally does not need to be set. If set,
+  follows the convention of [strconv.ParseBool](https://golang.org/pkg/strconv/#ParseBool).

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -59,6 +59,9 @@ The following arguments are supported:
   `additional_primaries` (default must be accepted).
 * `nx_ttl` - (Optional/Computed) The SOA NX TTL. Conflicts with `primary` and
   `additional_primaries` (default must be accepted).
+* `dnssec` - (Optional/Computed) Whether or not DNSSEC is enabled for the zone.
+  Note that DNSSEC must be enabled on the account by support for this to be set
+  to `true`.
 * `networks` - (Optional/Computed) List of network IDs for which the zone is
   available. If no network is provided, the zone will be created in network 0,
   the primary NS1 Global Network.


### PR DESCRIPTION
* Ensure that leaving DNSSEC unset, or removing the setting, doesn't change
  existing value.
* pre-check for DNSSEC tests tries to create a zone with DNSSEC=true,
  if it fails due to account permissions, we skip the test.