### PR TITLE
BUGFIX: disallow setting SOA fields on secondary zones

### DIFF
--- a/ns1/resource_zone.go
+++ b/ns1/resource_zone.go
@@ -28,25 +28,29 @@ func resourceZone() *schema.Resource {
 			},
 			// SOA attributes per https://tools.ietf.org/html/rfc1035).
 			"refresh": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"primary", "additional_primaries"},
 			},
 			"retry": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"primary", "additional_primaries"},
 			},
 			"expiry": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"primary", "additional_primaries"},
 			},
 			// SOA MINUMUM overloaded as NX TTL per https://tools.ietf.org/html/rfc2308
 			"nx_ttl": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"primary", "additional_primaries"},
 			},
 			// TODO: test
 			"link": {

--- a/ns1/resource_zone_test.go
+++ b/ns1/resource_zone_test.go
@@ -337,10 +337,6 @@ func testAccZoneSecondary(zoneName string) string {
 	return fmt.Sprintf(`resource "ns1_zone" "it" {
   zone    = "%s"
   ttl     = 10800
-  refresh = 3600
-  retry   = 300
-  expiry  = 2592000
-  nx_ttl  = 3601
   primary = "1.1.1.1"
   additional_primaries = ["2.2.2.2", "3.3.3.3"]
 }

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -51,10 +51,14 @@ The following arguments are supported:
 * `additional_primaries` - (Optional) List of additional IPs for the primary
   zone. Conflicts with `secondaries`.
 * `ttl` - (Optional/Computed) The SOA TTL.
-* `refresh` - (Optional/Computed) The SOA Refresh.
-* `retry` - (Optional/Computed) The SOA Retry.
-* `expiry` - (Optional/Computed) The SOA Expiry.
-* `nx_ttl` - (Optional/Computed) The SOA NX TTL.
+* `refresh` - (Optional/Computed) The SOA Refresh. Conflicts with `primary` and
+  `additional_primaries` (default must be accepted).
+* `retry` - (Optional/Computed) The SOA Retry. Conflicts with `primary` and
+  `additional_primaries` (default must be accepted).
+* `expiry` - (Optional/Computed) The SOA Expiry. Conflicts with `primary` and
+  `additional_primaries` (default must be accepted).
+* `nx_ttl` - (Optional/Computed) The SOA NX TTL. Conflicts with `primary` and
+  `additional_primaries` (default must be accepted).
 * `networks` - (Optional/Computed) List of network IDs for which the zone is
   available. If no network is provided, the zone will be created in network 0,
   the primary NS1 Global Network.


### PR DESCRIPTION
Fields `refresh`, `retry`, `expiry`, and `nx_ttl` should not be
settable on secondary zones. API is now enforcing this on create
by discarding any changes from default. It had already been
discarding _updates_ to these fields on an existing secondary zone.

* Fix a broken test that was setting these fields on a secondary.
* Add ConflictsWith to the fields to prevent this, and update docs.