### PR TITLE
bump go version for CI and README (1.11+ to 1.12+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-  - "1.11.x"
+  - "1.12.x"
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.11+ (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.12+ (to build the provider plugin)
 
 Building The Provider
 ---------------------


### PR DESCRIPTION
1.11 still works but we're movin' on!