### PR TITLE
resource_record: add support for 'allow_override'

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -385,7 +385,7 @@ func RecordCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if _, err := client.Records.Create(r); err != nil {
-		if !d.Get("allow_overwrite").(bool) && err.Error() != "record already exists" {
+		if !d.Get("allow_overwrite").(bool) || err.Error() != "record already exists" {
 			return err
 		}
 


### PR DESCRIPTION
At the moment, when creating a new zone through terraform, it is not possible to support the automatic modification of the nameservers at the same time. In fact, when trying to create the zone and adding the `NS` records, we end-up with a `Error: record already exists` response, as the `NS` records have been automatically created while creating the zone, but are not yet imported in the terraform state.

Workarounds at the moment are manual; we can either:
- Import the `NS` records after creating the zone, then re-run `terraform apply`
- Go into the NS1 interface (or through the API) to delete the `NS` records, then re-run `terraform apply`

The AWS Route53 provider offers a workaround [in the form of a `allow_overwrite` keyword](https://www.terraform.io/docs/providers/aws/r/route53_record.html#ns-and-soa-record-management), which makes the terraform provider automatically delete the record and recreate one when the record already exists at creation time. This allows for Route53 to edit both the `SOA` and `NS` records at the same time as when creating the zone, without any manual intervention.

This is thus inspired by that to implement the same feature, and allow to edit NS records right after creation.