### PR TITLE
ns1_zone: add a new 'autogenerate_ns_record' parameter defaulting to 'true'

### DIFF
--- a/ns1/resource_zone.go
+++ b/ns1/resource_zone.go
@@ -125,9 +125,6 @@ func resourceZone() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
 			},
 		},
 		Create:   zoneCreate,

--- a/ns1/resource_zone.go
+++ b/ns1/resource_zone.go
@@ -2,6 +2,7 @@ package ns1
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/customdiff"
@@ -119,6 +120,14 @@ func resourceZone() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
+			},
+			"autogenerate_ns_record": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 		},
 		Create:   zoneCreate,
@@ -283,6 +292,12 @@ func zoneCreate(d *schema.ResourceData, meta interface{}) error {
 	resourceDataToZone(z, d)
 	if _, err := client.Zones.Create(z); err != nil {
 		return err
+	}
+	if !d.Get("autogenerate_ns_record").(bool) {
+		log.Printf("autogenerate_ns_record set to false: deleting NS record for zone %s", z.Zone)
+		if _, err := client.Records.Delete(z.Zone, z.Zone, "NS"); err != nil {
+			return err
+		}
 	}
 	if err := resourceZoneToResourceData(d, z); err != nil {
 		return err


### PR DESCRIPTION
This new parameters is only used on creating a zone and allows to
prevent for NS records to be created automatically, which would
prevent users to create those records by themselves. This does it
by actually removing the auto-created NS record when the option
is set to 'false'. By default, the option is set to 'true'. We
also ignore any change to that value after creation, as it will
not imply any change to the deployed resource.

Following the discussion we've had on https://github.com/terraform-providers/terraform-provider-ns1/pull/77