### PR TITLE
INT-24: secondaries port and notify defaults

### DIFF
--- a/ns1/resource_zone.go
+++ b/ns1/resource_zone.go
@@ -99,12 +99,12 @@ func resourceZone() *schema.Resource {
 						"notify": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Computed: true,
 						},
 						"port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      53,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 65535),
 						},
 						"networks": &schema.Schema{


### PR DESCRIPTION
Defaults for these fields from Optional/Default to Optional/Computed,
so we don't send them when unset. This was breaking CIDR ranges for
IP, as the port cannot be explicitly set with them.