### PR TITLE
Add config option to use an alternate rate limit strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/terraform-providers/terraform-provider-ns1
 require (
 	github.com/fatih/structs v1.0.0
 	github.com/hashicorp/terraform v0.12.3
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.0.0-20191010201104-2adb9d02ee18
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/ns1/ns1-go.v2 v2.0.0-20191029201448-da571caa8ebc
+	gopkg.in/yaml.v2 v2.2.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -480,14 +482,14 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ns1/ns1-go.v2 v2.0.0-20191010201104-2adb9d02ee18 h1:EWHzc0KRRoBmj3293NmEIRaoFLXAU3jzM0ksB7BMeNQ=
-gopkg.in/ns1/ns1-go.v2 v2.0.0-20191010201104-2adb9d02ee18/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20191029201448-da571caa8ebc h1:ijjqb1dAvWSvtMdAd+DJXmRP777nU2ZA//fZBxUrUyk=
+gopkg.in/ns1/ns1-go.v2 v2.0.0-20191029201448-da571caa8ebc/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -18,9 +18,10 @@ import (
 
 // Config for NS1 API
 type Config struct {
-	Key       string
-	Endpoint  string
-	IgnoreSSL bool
+	Key                  string
+	Endpoint             string
+	IgnoreSSL            bool
+	RateLimitParallelism int
 }
 
 // Client returns a new NS1 client.
@@ -54,7 +55,11 @@ func (c *Config) Client() (*ns1.Client, error) {
 		client = ns1.NewClient(httpClient, decos...)
 	}
 
-	client.RateLimitStrategySleep()
+	if parallelism := c.RateLimitParallelism; parallelism > 0 {
+		client.RateLimitStrategyConcurrent(parallelism)
+	} else {
+		client.RateLimitStrategySleep()
+	}
 
 	log.Printf("[INFO] NS1 Client configured for Endpoint: %s", client.Endpoint.String())
 

--- a/ns1/provider.go
+++ b/ns1/provider.go
@@ -31,6 +31,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("NS1_IGNORE_SSL", nil),
 				Description: descriptions["ignore_ssl"],
 			},
+			"rate_limit_parallelism": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NS1_RATE_LIMIT_PARALLELISM", nil),
+				Description: descriptions["rate_limit_parallelism"],
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ns1_zone":   dataSourceZone(),
@@ -73,6 +79,9 @@ func ns1Configure(d *schema.ResourceData) (interface{}, error) {
 	}
 	if v, ok := d.GetOk("ignore_ssl"); ok {
 		config.IgnoreSSL = v.(bool)
+	}
+	if v, ok := d.GetOk("rate_limit_parallelism"); ok {
+		config.RateLimitParallelism = v.(int)
 	}
 
 	return config.Client()

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	clientVersion    = "2.0.0"
-	defaultEndpoint  = "https://api.nsone.net/v1/"
-	defaultUserAgent = "go-ns1/" + clientVersion
+	clientVersion = "2.0.0"
+
+	defaultEndpoint               = "https://api.nsone.net/v1/"
+	defaultShouldFollowPagination = true
+	defaultUserAgent              = "go-ns1/" + clientVersion
 
 	headerAuth          = "X-NSONE-Key"
 	headerRateLimit     = "X-Ratelimit-Limit"
@@ -46,6 +48,9 @@ type Client struct {
 	// Func to call after response is returned in Do
 	RateLimitFunc func(RateLimit)
 
+	// Whether the client should handle paginated responses automatically.
+	FollowPagination bool
+
 	// From the excellent github-go client.
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
@@ -74,10 +79,11 @@ func NewClient(httpClient Doer, options ...func(*Client)) *Client {
 	}
 
 	c := &Client{
-		httpClient:    httpClient,
-		Endpoint:      endpoint,
-		RateLimitFunc: defaultRateLimitFunc,
-		UserAgent:     defaultUserAgent,
+		httpClient:       httpClient,
+		Endpoint:         endpoint,
+		RateLimitFunc:    defaultRateLimitFunc,
+		UserAgent:        defaultUserAgent,
+		FollowPagination: defaultShouldFollowPagination,
 	}
 
 	c.common.client = c
@@ -130,7 +136,14 @@ func SetRateLimitFunc(ratefunc func(rl RateLimit)) func(*Client) {
 	return func(c *Client) { c.RateLimitFunc = ratefunc }
 }
 
-// Do satisfies the Doer interface.
+// SetFollowPagination sets a Client instances' FollowPagination attribute.
+func SetFollowPagination(shouldFollow bool) func(*Client) {
+	return func(c *Client) { c.FollowPagination = shouldFollow }
+}
+
+// Do satisfies the Doer interface. resp will be nil if a non-HTTP error
+// occurs, otherwise it is available for inspection when the error reflects a
+// non-2XX response.
 func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -154,6 +167,33 @@ func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	}
 
 	return resp, err
+}
+
+// NextFunc knows how to get and parse additional info from uri into v.
+type NextFunc func(v *interface{}, uri string) (*http.Response, error)
+
+// DoWithPagination Does, and follows Link headers for pagination. The returned
+// Response is from the last URI visited - either the last page, or one that
+// responded with a non-2XX status. If a non-HTTP error occurs, resp will be
+// nil.
+func (c Client) DoWithPagination(req *http.Request, v interface{}, f NextFunc) (*http.Response, error) {
+	resp, err := c.Do(req, v)
+	if err != nil {
+		return resp, err
+	}
+
+	// See PLAT-188
+	forceHTTPS := c.Endpoint.Scheme == "https"
+
+	nextURI := ParseLink(resp.Header.Get("Link"), forceHTTPS).Next()
+	for nextURI != "" {
+		resp, err = f(&v, nextURI)
+		if err != nil {
+			return resp, err
+		}
+		nextURI = ParseLink(resp.Header.Get("Link"), forceHTTPS).Next()
+	}
+	return resp, nil
 }
 
 // NewRequest constructs and returns a http.Request.
@@ -308,4 +348,14 @@ func SetStringParam(key, val string) func(*url.Values) {
 // SetIntParam sets a url integer query param given the parameters name.
 func SetIntParam(key string, val int) func(*url.Values) {
 	return func(v *url.Values) { v.Set(key, strconv.Itoa(val)) }
+}
+
+func (c *Client) getURI(v interface{}, uri string) (*http.Response, error) {
+	req, err := c.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	// For non-2XX responses, Do returns the response as well as an error, for
+	// other errs, resp will be nil. Caller's responsibility to sort that out.
+	return c.Do(req, v)
 }

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/headers.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/headers.go
@@ -1,0 +1,103 @@
+package rest
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var (
+	commaRegexp      = regexp.MustCompile(`,\s{0,}`)
+	valueCommaRegexp = regexp.MustCompile(`([^"]),`)
+	equalRegexp      = regexp.MustCompile(` *= *`)
+	keyRegexp        = regexp.MustCompile(`[a-z*]+`)
+	linkRegexp       = regexp.MustCompile(`\A<(.+)>;(.+)\z`)
+	semiRegexp       = regexp.MustCompile(`; +`)
+	valRegexp        = regexp.MustCompile(`"+([^"]+)"+`)
+)
+
+// Links represents a Link Header, keyed by the Rel attribute
+type Links map[string]*Link
+
+// Link has a URI and its relation (next/prev/last/etc)
+type Link struct {
+	URI   string
+	Rel   string
+	Extra map[string]string
+}
+
+// Next gets the URI for "next", if present
+func (l Links) Next() string {
+	for k, v := range l {
+		if k == "next" {
+			return v.URI
+		}
+	}
+	return ""
+}
+
+// ParseLink parses a Link header value into a Links, mainly cribbed from:
+// https://github.com/peterhellberg/link/blob/master/link.go
+// The forceHTTPS parameter will rewrite any HTTP URLs it finds to HTTPS.
+func ParseLink(s string, forceHTTPS bool) Links {
+	if s == "" {
+		return nil
+	}
+
+	links := Links{}
+
+	s = valueCommaRegexp.ReplaceAllString(s, "$1")
+
+	for _, l := range commaRegexp.Split(s, -1) {
+		linkMatches := linkRegexp.FindAllStringSubmatch(l, -1)
+
+		if len(linkMatches) == 0 {
+			return nil
+		}
+
+		pieces := linkMatches[0]
+
+		// Make sure we have a reasonable URL
+		uri := ""
+		if url, err := url.ParseRequestURI(pieces[1]); err == nil {
+
+			// See PLAT-188
+			if forceHTTPS && url.Scheme == "http" {
+				url.Scheme = "https"
+			}
+
+			uri = url.String()
+		}
+
+		link := &Link{URI: uri, Extra: map[string]string{}}
+
+		for _, extra := range semiRegexp.Split(pieces[2], -1) {
+			vals := equalRegexp.Split(extra, -1)
+
+			key := keyRegexp.FindString(vals[0])
+			val := valRegexp.FindStringSubmatch(vals[1])[1]
+
+			if key == "rel" {
+				vals := strings.Split(val, " ")
+				rels := []string{vals[0]}
+
+				if len(vals) > 1 {
+					for _, v := range vals[1:] {
+						if !strings.HasPrefix(v, "http") {
+							rels = append(rels, v)
+						}
+					}
+				}
+
+				rel := strings.Join(rels, " ")
+
+				link.Rel = rel
+				links[rel] = link
+			} else {
+				link.Extra[key] = val
+			}
+		}
+	}
+
+	return links
+}

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/zone.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/zone.go
@@ -21,7 +21,12 @@ func (s *ZonesService) List() ([]*dns.Zone, *http.Response, error) {
 	}
 
 	zl := []*dns.Zone{}
-	resp, err := s.client.Do(req, &zl)
+	var resp *http.Response
+	if s.client.FollowPagination == true {
+		resp, err = s.client.DoWithPagination(req, &zl, s.nextZones)
+	} else {
+		resp, err = s.client.Do(req, &zl)
+	}
 	if err != nil {
 		return nil, resp, err
 	}
@@ -41,7 +46,12 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 	}
 
 	var z dns.Zone
-	resp, err := s.client.Do(req, &z)
+	var resp *http.Response
+	if s.client.FollowPagination == true {
+		resp, err = s.client.DoWithPagination(req, &z, s.nextRecords)
+	} else {
+		resp, err = s.client.Do(req, &z)
+	}
 	if err != nil {
 		switch err.(type) {
 		case *Error:
@@ -129,6 +139,44 @@ func (s *ZonesService) Delete(zone string) (*http.Response, error) {
 		return resp, err
 	}
 
+	return resp, nil
+}
+
+// nextZones is a pagination helper than gets and appends another list of zones
+// to the passed list.
+func (s *ZonesService) nextZones(v *interface{}, uri string) (*http.Response, error) {
+	tmpZl := []*dns.Zone{}
+	resp, err := s.client.getURI(&tmpZl, uri)
+	if err != nil {
+		return resp, err
+	}
+	zoneList, ok := (*v).(*[]*dns.Zone)
+	if !ok {
+		return nil, fmt.Errorf(
+			"incorrect value for v, expected value of type *[]*dns.Zone, got: %T", v,
+		)
+	}
+	*zoneList = append(*zoneList, tmpZl...)
+	return resp, nil
+}
+
+// nextRecords is a pagination helper tha gets and appends another set of
+// records to the passed zone.
+func (s *ZonesService) nextRecords(v *interface{}, uri string) (*http.Response, error) {
+	var tmpZone dns.Zone
+	resp, err := s.client.getURI(&tmpZone, uri)
+	if err != nil {
+		return resp, err
+	}
+	zone, ok := (*v).(*dns.Zone)
+	if !ok {
+		return nil, fmt.Errorf(
+			"incorrect value for v, expected value of type *dns.Zone, got: %T", v,
+		)
+	}
+	// Aside from Records, the rest of the zone data is identical in the
+	// paginated response.
+	zone.Records = append(zone.Records, tmpZone.Records...)
 	return resp, nil
 }
 

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -319,10 +319,14 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 }
 
 const (
-	// 400,000 decode operations is ~500kb of dense object declarations, or ~5kb of dense object declarations with 10000% alias expansion
+	// 400,000 decode operations is ~500kb of dense object declarations, or
+	// ~5kb of dense object declarations with 10000% alias expansion
 	alias_ratio_range_low = 400000
-	// 4,000,000 decode operations is ~5MB of dense object declarations, or ~4.5MB of dense object declarations with 10% alias expansion
+
+	// 4,000,000 decode operations is ~5MB of dense object declarations, or
+	// ~4.5MB of dense object declarations with 10% alias expansion
 	alias_ratio_range_high = 4000000
+
 	// alias_ratio_range is the range over which we scale allowed alias ratios
 	alias_ratio_range = float64(alias_ratio_range_high - alias_ratio_range_low)
 )
@@ -784,8 +788,7 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 	case mappingNode:
 		d.unmarshal(n, out)
 	case aliasNode:
-		an, ok := d.doc.anchors[n.value]
-		if ok && an.kind != mappingNode {
+		if n.alias != nil && n.alias.kind != mappingNode {
 			failWantMap()
 		}
 		d.unmarshal(n, out)
@@ -794,8 +797,7 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 		for i := len(n.children) - 1; i >= 0; i-- {
 			ni := n.children[i]
 			if ni.kind == aliasNode {
-				an, ok := d.doc.anchors[ni.value]
-				if ok && an.kind != mappingNode {
+				if ni.alias != nil && ni.alias.kind != mappingNode {
 					failWantMap()
 				}
 			} else if ni.kind != mappingNode {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -356,12 +356,12 @@ google.golang.org/grpc/credentials/internal
 google.golang.org/grpc/balancer/base
 google.golang.org/grpc/binarylog/grpc_binarylog_v1
 google.golang.org/grpc/internal/syscall
-# gopkg.in/ns1/ns1-go.v2 v2.0.0-20191010201104-2adb9d02ee18
+# gopkg.in/ns1/ns1-go.v2 v2.0.0-20191029201448-da571caa8ebc
 gopkg.in/ns1/ns1-go.v2/rest
 gopkg.in/ns1/ns1-go.v2/rest/model/account
 gopkg.in/ns1/ns1-go.v2/rest/model/data
 gopkg.in/ns1/ns1-go.v2/rest/model/dns
 gopkg.in/ns1/ns1-go.v2/rest/model/filter
 gopkg.in/ns1/ns1-go.v2/rest/model/monitor
-# gopkg.in/yaml.v2 v2.2.4
+# gopkg.in/yaml.v2 v2.2.5
 gopkg.in/yaml.v2

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,12 +37,21 @@ The following arguments are supported:
   be sourced from the `NS1_APIKEY` environment variable.
 * `version` - (Optional, but recommended if you don't like surprises) From
   output of `terraform init`.
+* `endpoint` - (Optional) NS1 API endpoint. For managed clients, this normally
+  should not be set.
+* `ignore_ssl` - (Optional) This normally does not need to be set.
+* `rate_limit_parallelism` - (Optional) Integer for parallelism amount
+  (terraform's default is 10). If set, uses an alternate strategy to handle
+  rate limiting from the NS1 API. Give this a try if you are processing a large
+  number of resource and running into `429` rate-limiting errors.
 
 ## Environment Variables
 
-The provider does check some environment variables:
+The provider does check some environment variables as an alternative to
+embedding in the config:
 
 * `NS1_APIKEY` - (string) Explained above.
-* `NS1_ENDPOINT` - (string) For managed clients, this normally should not be set.
-* `NS1_IGNORE_SSL` - (boolean) This normally does not need to be set. If set,
-  follows the convention of [strconv.ParseBool](https://golang.org/pkg/strconv/#ParseBool).
+* `NS1_ENDPOINT` - (string) Explained above.
+* `NS1_IGNORE_SSL` - (boolean) If set, follows the convention of
+  [strconv.ParseBool](https://golang.org/pkg/strconv/#ParseBool).
+* `NS1_RATE_LIMIT_PARALLELISM` - (int) Explained above.


### PR DESCRIPTION
* Adds `rate_limit_parallelism` option. This initiates an alternate
  strategy for avoiding 429s from rate limiting in the NS1 API.
* Improve documentation around provider arguments and environment
  variables
* Pick up latest SDK, go mod vendor, go mod tidy