### PR TITLE
Minor Documentation and Makefile fixes 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,13 @@ PKG_NAME=ns1
 
 default: build
 
+clean:
+	@if [[ -f $(GOPATH)/bin/terraform-provider-ns1 ]]; then \
+		rm $(GOPATH)/bin/terraform-provider-ns1; \
+	else \
+		echo "nothing to clean."; \
+	fi
+
 build: fmtcheck
 	go install
 

--- a/README.md
+++ b/README.md
@@ -347,9 +347,12 @@ For each of those resources, these parameters are available at the top level of 
 Developing The Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine 
+(version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH),
+as well as adding `$GOPATH/bin` to your `$PATH`.
 
-To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+To compile the provider, run `make build`. This will build the provider and put the provider binary in 
+the `$GOPATH/bin` directory.
 
 ```sh
 $ make bin


### PR DESCRIPTION
While working issue #38, I made a couple small fixes to the README.md file and make file.  These seemed like low-hanging fruit while I was working.

(1) There were a couple lines that ran off to the right.  I wrapped them so they were consistent with the rest of the README.md formatting and easier to read when looking at multiple files at the same time.

(2) I added `make clean` as a rule in the make file so we can do things like `make clean build` and know the earlier artifact was removed prior to building a new one.

Happy Hacking!
