### PR TITLE
Issue 26: ns1_record refresh does not support resources disappearing

### DIFF
--- a/ns1/examples/record.tf
+++ b/ns1/examples/record.tf
@@ -1,8 +1,9 @@
 resource "ns1_record" "it" {
   #required
-  zone   = "${ns1_zone.test.zone}"
-  domain = "test.${ns1_zone.test.zone}"
-  type   = "CNAME"
+  zone             = ns1_zone.test.zone
+  domain           = "test.${ns1_zone.test.zone}"
+  type             = "CNAME"
+  OverwriteAllowed = false
 
   #optional
   ttl               = 60
@@ -47,6 +48,7 @@ resource "ns1_record" "it" {
 
   regions {
     name = "ExampleRegionB"
+
     meta = {
       country = "AS,AU,CC,CK,CX,FJ,FM,GU,HM,KI,MH,MP,NC,NF,NR,NU,NZ,PF,PG,PN,PW,SB,TK,TO,TV,U9,VU,WF,WS"
       up      = false
@@ -63,7 +65,10 @@ resource "ns1_record" "it" {
 
   filters {
     filter = "select_first_n"
-    config = { N = 1 }
+
+    config = {
+      N = 1
+    }
   }
 }
 

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -414,7 +414,7 @@ func RecordUpdate(d *schema.ResourceData, meta interface{}) error {
 			/*
 				If NS1 returns ErrRecordMissing, and if the user has specified OverwriteAllowed
 				then we will call RecordCreate and create a new record.
-			 */
+			*/
 			return RecordCreate(d, meta)
 		}
 		return err

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -377,6 +377,15 @@ func RecordCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if _, err := client.Records.Create(r); err != nil {
+		if err == ns1.ErrRecordExists && d.Get("OverwriteAllowed").(bool) {
+			/*
+					If NS1 returns ErrRecordExists, and if the user has specified OverwriteAllowed
+					then we will call RecordUpdate() to update the existing record.  We do this rather
+					than call RecordDelete() and RecordCreate() because there is a risk of a nasty loop
+				    starting.
+			*/
+			return RecordUpdate(d, meta)
+		}
 		return err
 	}
 	return recordToResourceData(d, r)

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -410,6 +410,13 @@ func RecordUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if _, err := client.Records.Update(r); err != nil {
+		if err == ns1.ErrRecordMissing && d.Get("OverwriteAllowed").(bool) {
+			/*
+				If NS1 returns ErrRecordMissing, and if the user has specified OverwriteAllowed
+				then we will call RecordCreate and create a new record.
+			 */
+			return RecordCreate(d, meta)
+		}
 		return err
 	}
 	return recordToResourceData(d, r)


### PR DESCRIPTION
**Problem Statement:**
This pull request addresses the problem reported in [Issue #26](https://github.com/terraform-providers/terraform-provider-ns1/issues/26).

**Solution:**
1. We implement an OverwiteAllowed (bool) flag.
2. On Update, if NS1 SDK returns ErrRecordMissing and OverwriteAllowed is true, we will create the record.  This will overcome the situation where an update fails to proceed when a record has disappeared or been damaged by some other source.
