### PR TITLE
Change Error strings to comply with golang standard.

### DIFF
--- a/ns1/data_source_dnssec_test.go
+++ b/ns1/data_source_dnssec_test.go
@@ -101,28 +101,28 @@ func testAccCheckDataSourceDNSSECDelegation(
 ) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if d.Delegation.TTL != 3600 {
-			return fmt.Errorf("Delegation.TTL want 3600, got %d", d.Delegation.TTL)
+			return fmt.Errorf("d.Delegation.TTL want 3600, got %d", d.Delegation.TTL)
 		}
 
 		if len(d.Delegation.DNSKey) != 1 {
 			return fmt.Errorf(
-				"Delgation.DNSKey length: want 1, got %d", len(d.Delegation.DNSKey),
+				"d.Delgation.DNSKey length: want 1, got %d", len(d.Delegation.DNSKey),
 			)
 		}
 		for i := range d.Delegation.DNSKey {
 			if err := testAccCheckDNSKey(d.Delegation.DNSKey[i]); err != nil {
-				return fmt.Errorf("Delegation.DNSKey[%d]: %s", i, err)
+				return fmt.Errorf("d.Delegation.DNSKey[%d]: %s", i, err)
 			}
 		}
 
 		if len(d.Delegation.DS) != 1 {
 			return fmt.Errorf(
-				"Delegation.DS length: want 1, got %d", len(d.Delegation.DS),
+				"d.Delegation.DS length: want 1, got %d", len(d.Delegation.DS),
 			)
 		}
 		for i := range d.Delegation.DS {
 			if err := testAccCheckDNSKey(d.Delegation.DS[i]); err != nil {
-				return fmt.Errorf("Delegation.DS[%d]: %s", i, err)
+				return fmt.Errorf("d.Delegation.DS[%d]: %s", i, err)
 			}
 		}
 
@@ -132,16 +132,16 @@ func testAccCheckDataSourceDNSSECDelegation(
 
 func testAccCheckDNSKey(key *dns.Key) error {
 	if key.Flags == "" {
-		return fmt.Errorf("Flags is empty")
+		return fmt.Errorf("flags is empty")
 	}
 	if key.Protocol == "" {
-		return fmt.Errorf("Protocol is empty")
+		return fmt.Errorf("protocol is empty")
 	}
 	if key.Algorithm == "" {
-		return fmt.Errorf("Algorithm is empty")
+		return fmt.Errorf("algorithm is empty")
 	}
 	if key.PublicKey == "" {
-		return fmt.Errorf("PublicKey is empty")
+		return fmt.Errorf("publicKey is empty")
 	}
 	return nil
 }

--- a/ns1/resource_datafeed_test.go
+++ b/ns1/resource_datafeed_test.go
@@ -63,15 +63,15 @@ func testAccCheckDataFeedExists(n string, dsrc string, dataFeed *data.Feed, t *t
 		ds, ok := s.RootModule().Resources[dsrc]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("NoID is set")
+			return fmt.Errorf("noID is set")
 		}
 
 		if ds.Primary.ID == "" {
-			return fmt.Errorf("NoID is set for the datasource")
+			return fmt.Errorf("noID is set for the datasource")
 		}
 
 		client := testAccProvider.Meta().(*ns1.Client)
@@ -114,7 +114,7 @@ func testAccCheckDataFeedDestroy(s *terraform.State) error {
 
 	df, _, _ := client.DataFeeds.Get(dataSourceID, dataFeedID)
 	if df != nil {
-		return fmt.Errorf("DataFeed still exists: %#v", df)
+		return fmt.Errorf("dataFeed still exists: %#v", df)
 	}
 
 	return nil
@@ -123,7 +123,7 @@ func testAccCheckDataFeedDestroy(s *terraform.State) error {
 func testAccCheckDataFeedName(dataFeed *data.Feed, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if dataFeed.Name != expected {
-			return fmt.Errorf("Name: got: %#v want: %#v", dataFeed.Name, expected)
+			return fmt.Errorf("dataFeed.Name: got: %#v want: %#v", dataFeed.Name, expected)
 		}
 
 		return nil
@@ -134,7 +134,7 @@ func testAccCheckDataFeedConfig(dataFeed *data.Feed, key, expected string) resou
 	return func(s *terraform.State) error {
 
 		if dataFeed.Config[key] != expected {
-			return fmt.Errorf("Config[%s]: got: %#v, want: %s", key, dataFeed.Config[key], expected)
+			return fmt.Errorf("dataFeed.Config[%s]: got: %#v, want: %s", key, dataFeed.Config[key], expected)
 		}
 
 		return nil

--- a/ns1/resource_datasource_test.go
+++ b/ns1/resource_datasource_test.go
@@ -62,11 +62,11 @@ func testAccCheckDataSourceExists(n string, dataSource *data.Source) resource.Te
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("NoID is set")
+			return fmt.Errorf("noID is set")
 		}
 
 		client := testAccProvider.Meta().(*ns1.Client)
@@ -80,7 +80,7 @@ func testAccCheckDataSourceExists(n string, dataSource *data.Source) resource.Te
 		}
 
 		if foundSource.Name != p.Attributes["name"] {
-			return fmt.Errorf("Datasource not found")
+			return fmt.Errorf("datasource not found")
 		}
 
 		*dataSource = *foundSource
@@ -100,7 +100,7 @@ func testAccCheckDataSourceDestroy(s *terraform.State) error {
 		_, _, err := client.DataSources.Get(rs.Primary.Attributes["id"])
 
 		if err == nil {
-			return fmt.Errorf("Datasource still exists")
+			return fmt.Errorf("datasource still exists")
 		}
 	}
 
@@ -110,7 +110,7 @@ func testAccCheckDataSourceDestroy(s *terraform.State) error {
 func testAccCheckDataSourceName(dataSource *data.Source, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if dataSource.Name != expected {
-			return fmt.Errorf("Name: got: %#v want: %#v", dataSource.Name, expected)
+			return fmt.Errorf("dataSource.Name: got: %#v want: %#v", dataSource.Name, expected)
 		}
 
 		return nil
@@ -120,7 +120,7 @@ func testAccCheckDataSourceName(dataSource *data.Source, expected string) resour
 func testAccCheckDataSourceType(dataSource *data.Source, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if dataSource.Type != expected {
-			return fmt.Errorf("Type: got: %#v want: %#v", dataSource.Type, expected)
+			return fmt.Errorf("dataSource.Type: got: %#v want: %#v", dataSource.Type, expected)
 		}
 
 		return nil

--- a/ns1/resource_monitoringjob_test.go
+++ b/ns1/resource_monitoringjob_test.go
@@ -95,11 +95,11 @@ func testAccCheckMonitoringJobState(key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources["ns1_monitoringjob.it"]
 		if !ok {
-			return fmt.Errorf("Not found: %s", "ns1_monitoringjob.it")
+			return fmt.Errorf("not found: %s", "ns1_monitoringjob.it")
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		p := rs.Primary
@@ -117,7 +117,7 @@ func testAccCheckMonitoringJobExists(n string, monitoringJob *monitor.Job) resou
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Resource not found: %v", n)
+			return fmt.Errorf("resource not found: %v", n)
 		}
 
 		id := rs.Primary.ID
@@ -134,7 +134,7 @@ func testAccCheckMonitoringJobExists(n string, monitoringJob *monitor.Job) resou
 		}
 
 		if foundMj.ID != id {
-			return fmt.Errorf("Monitoring Job not found want: %#v, got %#v", id, foundMj)
+			return fmt.Errorf("monitoring Job not found want: %#v, got %#v", id, foundMj)
 		}
 
 		*monitoringJob = *foundMj
@@ -154,7 +154,7 @@ func testAccCheckMonitoringJobDestroy(s *terraform.State) error {
 		mj, _, err := client.Jobs.Get(rs.Primary.Attributes["id"])
 
 		if err == nil {
-			return fmt.Errorf("Monitoring Job still exists %#v: %#v", err, mj)
+			return fmt.Errorf("monitoring Job still exists %#v: %#v", err, mj)
 		}
 	}
 
@@ -164,7 +164,7 @@ func testAccCheckMonitoringJobDestroy(s *terraform.State) error {
 func testAccCheckMonitoringJobName(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Name != expected {
-			return fmt.Errorf("Name: got: %#v want: %#v", mj.Name, expected)
+			return fmt.Errorf("mj.Name: got: %#v want: %#v", mj.Name, expected)
 		}
 		return nil
 	}
@@ -173,7 +173,7 @@ func testAccCheckMonitoringJobName(mj *monitor.Job, expected string) resource.Te
 func testAccCheckMonitoringJobActive(mj *monitor.Job, expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Active != expected {
-			return fmt.Errorf("Active: got: %#v want: %#v", mj.Active, expected)
+			return fmt.Errorf("mj.Active: got: %#v want: %#v", mj.Active, expected)
 		}
 		return nil
 	}
@@ -182,7 +182,7 @@ func testAccCheckMonitoringJobActive(mj *monitor.Job, expected bool) resource.Te
 func testAccCheckMonitoringJobRegions(mj *monitor.Job, expected []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if !reflect.DeepEqual(mj.Regions, expected) {
-			return fmt.Errorf("Regions: got: %#v want: %#v", mj.Regions, expected)
+			return fmt.Errorf("mj.Regions: got: %#v want: %#v", mj.Regions, expected)
 		}
 		return nil
 	}
@@ -191,7 +191,7 @@ func testAccCheckMonitoringJobRegions(mj *monitor.Job, expected []string) resour
 func testAccCheckMonitoringJobType(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Type != expected {
-			return fmt.Errorf("Type: got: %#v want: %#v", mj.Type, expected)
+			return fmt.Errorf("mj.Type: got: %#v want: %#v", mj.Type, expected)
 		}
 		return nil
 	}
@@ -200,7 +200,7 @@ func testAccCheckMonitoringJobType(mj *monitor.Job, expected string) resource.Te
 func testAccCheckMonitoringJobFrequency(mj *monitor.Job, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Frequency != expected {
-			return fmt.Errorf("Frequency: got: %#v want: %#v", mj.Frequency, expected)
+			return fmt.Errorf("mj.Frequency: got: %#v want: %#v", mj.Frequency, expected)
 		}
 		return nil
 	}
@@ -209,7 +209,7 @@ func testAccCheckMonitoringJobFrequency(mj *monitor.Job, expected int) resource.
 func testAccCheckMonitoringJobRapidRecheck(mj *monitor.Job, expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.RapidRecheck != expected {
-			return fmt.Errorf("RapidRecheck: got: %#v want: %#v", mj.RapidRecheck, expected)
+			return fmt.Errorf("mj.RapidRecheck: got: %#v want: %#v", mj.RapidRecheck, expected)
 		}
 		return nil
 	}
@@ -218,7 +218,7 @@ func testAccCheckMonitoringJobRapidRecheck(mj *monitor.Job, expected bool) resou
 func testAccCheckMonitoringJobPolicy(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Policy != expected {
-			return fmt.Errorf("Policy: got: %#v want: %#v", mj.Policy, expected)
+			return fmt.Errorf("mj.Policy: got: %#v want: %#v", mj.Policy, expected)
 		}
 		return nil
 	}
@@ -227,7 +227,7 @@ func testAccCheckMonitoringJobPolicy(mj *monitor.Job, expected string) resource.
 func testAccCheckMonitoringJobConfigSend(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Config["send"].(string) != expected {
-			return fmt.Errorf("Config.send: got: %#v want: %#v", mj.Config["send"].(string), expected)
+			return fmt.Errorf("mj.Config.send: got: %#v want: %#v", mj.Config["send"].(string), expected)
 		}
 		return nil
 	}
@@ -236,7 +236,7 @@ func testAccCheckMonitoringJobConfigSend(mj *monitor.Job, expected string) resou
 func testAccCheckMonitoringJobConfigPort(mj *monitor.Job, expected float64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Config["port"].(float64) != expected {
-			return fmt.Errorf("Config.port: got: %#v want: %#v", mj.Config["port"].(float64), expected)
+			return fmt.Errorf("mj.Config.port: got: %#v want: %#v", mj.Config["port"].(float64), expected)
 		}
 		return nil
 	}
@@ -245,7 +245,7 @@ func testAccCheckMonitoringJobConfigPort(mj *monitor.Job, expected float64) reso
 func testAccCheckMonitoringJobConfigHost(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Config["host"].(string) != expected {
-			return fmt.Errorf("Config.host: got: %#v want: %#v", mj.Config["host"].(string), expected)
+			return fmt.Errorf("mj.Config.host: got: %#v want: %#v", mj.Config["host"].(string), expected)
 		}
 		return nil
 	}
@@ -254,7 +254,7 @@ func testAccCheckMonitoringJobConfigHost(mj *monitor.Job, expected string) resou
 func testAccCheckMonitoringJobRuleValue(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Rules[0].Value.(string) != expected {
-			return fmt.Errorf("Rules[0].Value: got: %#v want: %#v", mj.Rules[0].Value.(string), expected)
+			return fmt.Errorf("mj.Rules[0].Value: got: %#v want: %#v", mj.Rules[0].Value.(string), expected)
 		}
 		return nil
 	}
@@ -263,7 +263,7 @@ func testAccCheckMonitoringJobRuleValue(mj *monitor.Job, expected string) resour
 func testAccCheckMonitoringJobRuleComparison(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Rules[0].Comparison != expected {
-			return fmt.Errorf("Rules[0].Comparison: got: %#v want: %#v", mj.Rules[0].Comparison, expected)
+			return fmt.Errorf("mj.Rules[0].Comparison: got: %#v want: %#v", mj.Rules[0].Comparison, expected)
 		}
 		return nil
 	}
@@ -272,7 +272,7 @@ func testAccCheckMonitoringJobRuleComparison(mj *monitor.Job, expected string) r
 func testAccCheckMonitoringJobRuleKey(mj *monitor.Job, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if mj.Rules[0].Key != expected {
-			return fmt.Errorf("Rules[0].Key: got: %#v want: %#v", mj.Rules[0].Key, expected)
+			return fmt.Errorf("mj.Rules[0].Key: got: %#v want: %#v", mj.Rules[0].Key, expected)
 		}
 		return nil
 	}

--- a/ns1/resource_notifylist_test.go
+++ b/ns1/resource_notifylist_test.go
@@ -99,11 +99,11 @@ func testAccCheckNotifyListState(key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources["ns1_notifylist.test"]
 		if !ok {
-			return fmt.Errorf("Not found: %s", "ns1_notifylist.test")
+			return fmt.Errorf("not found: %s", "ns1_notifylist.test")
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		p := rs.Primary
@@ -121,7 +121,7 @@ func testAccCheckNotifyListExists(n string, nl *monitor.NotifyList) resource.Tes
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Resource not found: %v", n)
+			return fmt.Errorf("resource not found: %v", n)
 		}
 
 		id := rs.Primary.ID
@@ -138,7 +138,7 @@ func testAccCheckNotifyListExists(n string, nl *monitor.NotifyList) resource.Tes
 		}
 
 		if foundNl.ID != id {
-			return fmt.Errorf("Notify List not found want: %#v, got %#v", id, foundNl)
+			return fmt.Errorf("notify List not found want: %#v, got %#v", id, foundNl)
 		}
 
 		*nl = *foundNl
@@ -158,7 +158,7 @@ func testAccCheckNotifyListDestroy(s *terraform.State) error {
 		nl, _, err := client.Notifications.Get(rs.Primary.Attributes["id"])
 
 		if err == nil {
-			return fmt.Errorf("Notify List still exists %#v: %#v", err, nl)
+			return fmt.Errorf("notify List still exists %#v: %#v", err, nl)
 		}
 	}
 
@@ -168,7 +168,7 @@ func testAccCheckNotifyListDestroy(s *terraform.State) error {
 func testAccCheckNotifyListName(nl *monitor.NotifyList, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if nl.Name != expected {
-			return fmt.Errorf("Name: got: %#v want: %#v", nl.Name, expected)
+			return fmt.Errorf("nl.Name: got: %#v want: %#v", nl.Name, expected)
 		}
 		return nil
 	}

--- a/ns1/resource_record_test.go
+++ b/ns1/resource_record_test.go
@@ -235,11 +235,11 @@ func testAccCheckRecordExists(n string, record *dns.Record) resource.TestCheckFu
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %v", n)
+			return fmt.Errorf("not found: %v", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("NoID is set")
+			return fmt.Errorf("noID is set")
 		}
 
 		client := testAccProvider.Meta().(*ns1.Client)
@@ -248,11 +248,11 @@ func testAccCheckRecordExists(n string, record *dns.Record) resource.TestCheckFu
 
 		foundRecord, _, err := client.Records.Get(p.Attributes["zone"], p.Attributes["domain"], p.Attributes["type"])
 		if err != nil {
-			return fmt.Errorf("Record not found")
+			return fmt.Errorf("record not found")
 		}
 
 		if foundRecord.Domain != p.Attributes["domain"] {
-			return fmt.Errorf("Record not found")
+			return fmt.Errorf("record not found")
 		}
 
 		*record = *foundRecord
@@ -282,7 +282,7 @@ func testAccCheckRecordDestroy(s *terraform.State) error {
 
 	foundRecord, _, err := client.Records.Get(recordZone, recordDomain, recordType)
 	if err != ns1.ErrRecordMissing {
-		return fmt.Errorf("Record still exists: %#v %#v", foundRecord, err)
+		return fmt.Errorf("record still exists: %#v %#v", foundRecord, err)
 	}
 
 	return nil
@@ -291,7 +291,7 @@ func testAccCheckRecordDestroy(s *terraform.State) error {
 func testAccCheckRecordDomain(r *dns.Record, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if r.Domain != expected {
-			return fmt.Errorf("Domain: got: %#v want: %#v", r.Domain, expected)
+			return fmt.Errorf("r.Domain: got: %#v want: %#v", r.Domain, expected)
 		}
 		return nil
 	}
@@ -300,7 +300,7 @@ func testAccCheckRecordDomain(r *dns.Record, expected string) resource.TestCheck
 func testAccCheckRecordTTL(r *dns.Record, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if r.TTL != expected {
-			return fmt.Errorf("TTL: got: %#v want: %#v", r.TTL, expected)
+			return fmt.Errorf("r.TTL: got: %#v want: %#v", r.TTL, expected)
 		}
 		return nil
 	}
@@ -327,7 +327,7 @@ func testAccCheckRecordRegionName(r *dns.Record, expected []string) resource.Tes
 		sort.Strings(regions)
 		sort.Strings(expected)
 		if !reflect.DeepEqual(regions, expected) {
-			return fmt.Errorf("Regions: got: %#v want: %#v", regions, expected)
+			return fmt.Errorf("regions: got: %#v want: %#v", regions, expected)
 		}
 		return nil
 	}
@@ -339,7 +339,7 @@ func testAccCheckRecordAnswerMetaWeight(r *dns.Record, expected float64) resourc
 		recordMetas := recordAnswer.Meta
 		weight := recordMetas.Weight.(float64)
 		if weight != expected {
-			return fmt.Errorf("Answers[0].Meta.Weight: got: %#v want: %#v", weight, expected)
+			return fmt.Errorf("r.Answers[0].Meta.Weight: got: %#v want: %#v", weight, expected)
 		}
 		return nil
 	}

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -49,7 +49,7 @@ func testAccCheckUserDestroy(s *terraform.State) error {
 
 		user, _, err := client.Users.Get(rs.Primary.Attributes["id"])
 		if err == nil {
-			return fmt.Errorf("User still exists: %#v: %#v", err, user.Name)
+			return fmt.Errorf("user still exists: %#v: %#v", err, user.Name)
 		}
 	}
 
@@ -60,11 +60,11 @@ func testAccCheckUserExists(n string, user *account.User) resource.TestCheckFunc
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		client := testAccProvider.Meta().(*ns1.Client)
@@ -75,7 +75,7 @@ func testAccCheckUserExists(n string, user *account.User) resource.TestCheckFunc
 		}
 
 		if foundUser.Username != rs.Primary.ID {
-			return fmt.Errorf("User not found (%#v != %s)", foundUser, rs.Primary.ID)
+			return fmt.Errorf("user not found (%#v != %s)", foundUser, rs.Primary.ID)
 		}
 
 		*user = *foundUser

--- a/ns1/resource_zone_test.go
+++ b/ns1/resource_zone_test.go
@@ -364,11 +364,11 @@ func testAccCheckZoneExists(n string, zone *dns.Zone) resource.TestCheckFunc {
 		rs, ok := s.RootModule().Resources[n]
 
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		client := testAccProvider.Meta().(*ns1.Client)
@@ -382,7 +382,7 @@ func testAccCheckZoneExists(n string, zone *dns.Zone) resource.TestCheckFunc {
 		}
 
 		if foundZone.ID != p.Attributes["id"] {
-			return fmt.Errorf("Zone not found")
+			return fmt.Errorf("zone not found")
 		}
 
 		*zone = *foundZone
@@ -433,10 +433,10 @@ func testAccCheckNSRecord(n string, expected bool) resource.TestCheckFunc {
 			}
 
 			if foundRecord.Domain != p.Attributes["zone"] {
-				return fmt.Errorf("NS Record found, but domain does not match")
+				return fmt.Errorf("an NS Record found, but domain does not match")
 			}
 		} else if err == nil {
-			return fmt.Errorf("NS Record found (autogenerate_ns_record set to false)")
+			return fmt.Errorf("an NS Record found (autogenerate_ns_record set to false)")
 		}
 
 		return nil
@@ -454,7 +454,7 @@ func testAccCheckZoneDestroy(s *terraform.State) error {
 		zone, _, err := client.Zones.Get(rs.Primary.Attributes["zone"])
 
 		if err == nil {
-			return fmt.Errorf("Zone still exists: %#v: %#v", err, zone)
+			return fmt.Errorf("zone still exists: %#v: %#v", err, zone)
 		}
 	}
 
@@ -464,7 +464,7 @@ func testAccCheckZoneDestroy(s *terraform.State) error {
 func testAccCheckZoneName(zone *dns.Zone, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if zone.Zone != expected {
-			return fmt.Errorf("Zone: got: %s want: %s", zone.Zone, expected)
+			return fmt.Errorf("zone: got: %s want: %s", zone.Zone, expected)
 		}
 		return nil
 	}
@@ -473,7 +473,7 @@ func testAccCheckZoneName(zone *dns.Zone, expected string) resource.TestCheckFun
 func testAccCheckZoneTTL(zone *dns.Zone, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if zone.TTL != expected {
-			return fmt.Errorf("TTL: got: %d want: %d", zone.TTL, expected)
+			return fmt.Errorf("zone.TTL: got: %d want: %d", zone.TTL, expected)
 		}
 		return nil
 	}
@@ -481,7 +481,7 @@ func testAccCheckZoneTTL(zone *dns.Zone, expected int) resource.TestCheckFunc {
 func testAccCheckZoneRefresh(zone *dns.Zone, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if zone.Refresh != expected {
-			return fmt.Errorf("Refresh: got: %d want: %d", zone.Refresh, expected)
+			return fmt.Errorf("zone.Refresh: got: %d want: %d", zone.Refresh, expected)
 		}
 		return nil
 	}
@@ -489,7 +489,7 @@ func testAccCheckZoneRefresh(zone *dns.Zone, expected int) resource.TestCheckFun
 func testAccCheckZoneRetry(zone *dns.Zone, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if zone.Retry != expected {
-			return fmt.Errorf("Retry: got: %d want: %d", zone.Retry, expected)
+			return fmt.Errorf("zone.Retry: got: %d want: %d", zone.Retry, expected)
 		}
 		return nil
 	}
@@ -497,7 +497,7 @@ func testAccCheckZoneRetry(zone *dns.Zone, expected int) resource.TestCheckFunc 
 func testAccCheckZoneExpiry(zone *dns.Zone, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if zone.Expiry != expected {
-			return fmt.Errorf("Expiry: got: %d want: %d", zone.Expiry, expected)
+			return fmt.Errorf("zone.Expiry: got: %d want: %d", zone.Expiry, expected)
 		}
 		return nil
 	}
@@ -505,7 +505,7 @@ func testAccCheckZoneExpiry(zone *dns.Zone, expected int) resource.TestCheckFunc
 func testAccCheckZoneNxTTL(zone *dns.Zone, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if zone.NxTTL != expected {
-			return fmt.Errorf("NxTTL: got: %d want: %d", zone.NxTTL, expected)
+			return fmt.Errorf("zone.NxTTL: got: %d want: %d", zone.NxTTL, expected)
 		}
 		return nil
 	}
@@ -528,10 +528,10 @@ func testAccCheckOtherPorts(zone *dns.Zone, expected []int) resource.TestCheckFu
 func testAccCheckZoneNotPrimary(z *dns.Zone) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if z.Primary.Enabled != false {
-			return fmt.Errorf("Primary.Enabled: got: true want: false")
+			return fmt.Errorf("z.Primary.Enabled: got: true want: false")
 		}
 		if len(z.Primary.Secondaries) != 0 {
-			return fmt.Errorf("Secondaries: got: len(%d) want: len(0)", len(z.Primary.Secondaries))
+			return fmt.Errorf("secondaries: got: len(%d) want: len(0)", len(z.Primary.Secondaries))
 		}
 		return nil
 	}
@@ -542,7 +542,7 @@ func testAccCheckZoneNotSecondary(z *dns.Zone) resource.TestCheckFunc {
 		if z.Secondary != nil {
 			// Note that other fields are not cleared. We just toggle "enabled"
 			if z.Secondary.Enabled != false {
-				return fmt.Errorf("Secondary.Enabled: got: true want: false")
+				return fmt.Errorf("z.Secondary.Enabled: got: true want: false")
 			}
 		}
 		return nil


### PR DESCRIPTION
# Problem Statement
This pull request addresses [issue #92](https://github.com/terraform-providers/terraform-provider-ns1/issues/92).

# Solution 
Changed capitalization with minimal change, adding context where it helped to also satisfy this standard and make the error message more descriptive.
