### PR TITLE
records: handle zone/domain strings with leading/trailing dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ otherwise terraform will detect changes to the record when none actually exist.
 
 A record _requires_ a [Zone](#zone)
 
+The **zone** and **domain** fields should not have any leading or trailing dots (".").
+If the value is coming from another resource with a leading or trailing dot, it should be cleaned:
+
+`zone = replace(".terraform-test-zone.io.", "/(^\\.)|(\\.$)/", "")`
+
 _Example_
 ```hcl
 resource "ns1_record" "it" {

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -41,14 +41,16 @@ func recordResource() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			// Required
 			"zone": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateFQDN,
 			},
 			"domain": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateFQDN,
 			},
 			"type": {
 				Type:         schema.TypeString,
@@ -452,4 +454,19 @@ func regionsMetaDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	}
 
 	return false
+}
+
+// validateFQDN verifies that an FQDN doesn't have leading or trailing dots.
+func validateFQDN(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+
+	if strings.HasPrefix(v, ".") {
+		errs = append(errs, fmt.Errorf("%s has an invalid leading \".\", got: %s", key, v))
+	}
+
+	if strings.HasSuffix(v, ".") {
+		errs = append(errs, fmt.Errorf("%s has an invalid trailing \".\", got: %s", key, v))
+	}
+
+	return warns, errs
 }

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -92,7 +92,12 @@ resource "ns1_record" "www" {
 The following arguments are supported:
 
 * `zone` - (Required) The zone the record belongs to.
+Cannot have leading or trailing dots (".") and can be cleaned with:
+```
+zone = replace(".terraform-test-zone.io.", "/(^\\.)|(\\.$)/", "")
+```
 * `domain` - (Required) The records' domain.
+Cannot have leading or trailing dots and can be cleaned similarly to `zone`.
 * `type` - (Required) The records' RR type.
 * `ttl` - (Optional) The records' time to live.
 * `link` - (Optional) The target record to link to. This means this record is a


### PR DESCRIPTION
Adds validation to the zone and domain fields on a record to more clearly indicate invalid inputs containing leading or trailing dots