### PR TITLE
Clean up permission diffs on users and api keys

### DIFF
--- a/ns1/resource_team.go
+++ b/ns1/resource_team.go
@@ -89,5 +89,9 @@ func TeamUpdate(d *schema.ResourceData, meta interface{}) error {
 	if _, err := client.Teams.Update(&t); err != nil {
 		return err
 	}
+
+	// @TODO - when a teams permissions are updated, all users and keys assigned to that team
+	// should have their Terraform state refreshed, there is not a particularly nice way to implement this
+	// because teams don't have a concept of what users and keys are assigned to them, only the other way around.
 	return teamToResourceData(d, &t)
 }

--- a/ns1/resource_team_test.go
+++ b/ns1/resource_team_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -15,6 +16,7 @@ import (
 
 func TestAccTeam_basic(t *testing.T) {
 	var team account.Team
+	n := fmt.Sprintf("terraform test team %s", acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,10 +24,10 @@ func TestAccTeam_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTeamBasic,
+				Config: fmt.Sprintf(testAccTeamBasic, n),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTeamExists("ns1_team.foobar", &team),
-					testAccCheckTeamName(&team, "terraform test"),
+					testAccCheckTeamName(&team, n),
 					testAccCheckTeamDNSPermission(&team, "view_zones", true),
 					testAccCheckTeamDNSPermission(&team, "zones_allow_by_default", true),
 					testAccCheckTeamDNSPermissionZones(&team, "zones_allow", []string{"mytest.zone"}),
@@ -39,6 +41,7 @@ func TestAccTeam_basic(t *testing.T) {
 
 func TestAccTeam_updated(t *testing.T) {
 	var team account.Team
+	n := fmt.Sprintf("terraform test team %s", acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -46,17 +49,17 @@ func TestAccTeam_updated(t *testing.T) {
 		CheckDestroy: testAccCheckTeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTeamBasic,
+				Config: fmt.Sprintf(testAccTeamBasic, n),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTeamExists("ns1_team.foobar", &team),
-					testAccCheckTeamName(&team, "terraform test"),
+					testAccCheckTeamName(&team, n),
 				),
 			},
 			{
-				Config: testAccTeamUpdated,
+				Config: fmt.Sprintf(testAccTeamUpdated, n),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTeamExists("ns1_team.foobar", &team),
-					testAccCheckTeamName(&team, "terraform test updated"),
+					testAccCheckTeamName(&team, fmt.Sprintf("%s updated", n)),
 					testAccCheckTeamDNSPermission(&team, "view_zones", true),
 					testAccCheckTeamDNSPermission(&team, "zones_allow_by_default", true),
 					testAccCheckTeamDNSPermissionZones(&team, "zones_allow", []string{}),
@@ -230,7 +233,7 @@ func testAccManualDeleteTeam(team *account.Team) func() {
 
 const testAccTeamBasic = `
 resource "ns1_team" "foobar" {
-  name = "terraform test"
+  name = "%s"
 
   dns_view_zones = true
   dns_zones_allow_by_default = true
@@ -242,7 +245,7 @@ resource "ns1_team" "foobar" {
 
 const testAccTeamUpdated = `
 resource "ns1_team" "foobar" {
-  name = "terraform test updated"
+  name = "%s updated"
 
   dns_view_zones = true
   dns_zones_allow_by_default = true

--- a/website/docs/r/apikey.html.markdown
+++ b/website/docs/r/apikey.html.markdown
@@ -27,13 +27,20 @@ resource "ns1_apikey" "example" {
 }
 ```
 
+## Permissions
+An API key will inherit permissions from the teams it is assigned to.
+When a key is removed from all teams completely, it will inherit whatever permissions it had previously.
+If a key is removed from all it's teams, it will probably be necessary to run `terraform apply` a second time
+to update the keys permissions from it's old team permissions to new key-specific permissions.
+See [the NS1 API docs](https://ns1.com/api#getget-all-account-users) for an overview of permission semantics.
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The free form name of the apikey.
 * `key` - (Required) The apikeys authentication token.
-* `teams` - (Required) The teams that the apikey belongs to.
+* `teams` - (Optional) The teams that the apikey belongs to.
 * `dns_view_zones` - (Optional) Whether the apikey can view the accounts zones.
 * `dns_manage_zones` - (Optional) Whether the apikey can modify the accounts zones.
 * `dns_zones_allow_by_default` - (Optional) If true, enable the `dns_zones_allow` list, otherwise enable the `dns_zones_deny` list.

--- a/website/docs/r/apikey.html.markdown
+++ b/website/docs/r/apikey.html.markdown
@@ -29,9 +29,14 @@ resource "ns1_apikey" "example" {
 
 ## Permissions
 An API key will inherit permissions from the teams it is assigned to.
+If a key is assigned to a team and also has individual permissions set on the key, the individual permissions
+will be overridden by the inherited team permissions.
+In a future release, setting permissions on a key that is part of a team will be explicitly disabled.
+
 When a key is removed from all teams completely, it will inherit whatever permissions it had previously.
 If a key is removed from all it's teams, it will probably be necessary to run `terraform apply` a second time
 to update the keys permissions from it's old team permissions to new key-specific permissions.
+
 See [the NS1 API docs](https://ns1.com/api#getget-all-account-users) for an overview of permission semantics.
 
 ## Argument Reference

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -30,6 +30,13 @@ resource "ns1_user" "example" {
 }
 ```
 
+## Permissions
+A user will inherit permissions from the teams they are assigned to.
+When a user is removed from all teams completely, they will inherit whatever permissions they had previously.
+If a user is removed from all their teams, it will probably be necessary to run `terraform apply` a second time
+to update the users permissions from their old team permissions to new user-specific permissions.
+See [the NS1 API docs](https://ns1.com/api#getget-all-account-users) for an overview of permission semantics.
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -32,9 +32,14 @@ resource "ns1_user" "example" {
 
 ## Permissions
 A user will inherit permissions from the teams they are assigned to.
+If a user is assigned to a team and also has individual permissions set on the user, the individual permissions
+will be overridden by the inherited team permissions.
+In a future release, setting permissions on a user that is part of a team will be explicitly disabled.
+
 When a user is removed from all teams completely, they will inherit whatever permissions they had previously.
 If a user is removed from all their teams, it will probably be necessary to run `terraform apply` a second time
 to update the users permissions from their old team permissions to new user-specific permissions.
+
 See [the NS1 API docs](https://ns1.com/api#getget-all-account-users) for an overview of permission semantics.
 
 ## Argument Reference


### PR DESCRIPTION
I was able to get the diffs to suppress when a user or api key is part of a team. There is some quirkiness when something is removed from teams altogether though, because the user/key inherits the permissions it had previously, so you potentially have to run a second `apply` in order to update the permissions on the user/key to what is set in the config for that user/key. I documented that piece of it. 

This should close #15 