### PR TITLE
ddi permission support and ip whitelist support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/ns1/ns1-go.v2 v2.0.0-20191126161805-25b9eac84517
+	gopkg.in/ns1/ns1-go.v2 v2.2.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
-gopkg.in/ns1/ns1-go.v2 v2.0.0-20191126161805-25b9eac84517 h1:+LJW6vUk8hBtzF9z5/urQmaOb9JB2Cxh9P/OIbwIsfQ=
-gopkg.in/ns1/ns1-go.v2 v2.0.0-20191126161805-25b9eac84517/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
+gopkg.in/ns1/ns1-go.v2 v2.2.0 h1:Pfpo7swebnLVgMrrR95QuVjihwxIW4573CLHPtH6bm8=
+gopkg.in/ns1/ns1-go.v2 v2.2.0/go.mod h1:GMnKY+ZuoJ+lVLL+78uSTjwTz2jMazq6AfGKQOYhsPk=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=

--- a/ns1/config.go
+++ b/ns1/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Key                  string
 	Endpoint             string
 	IgnoreSSL            bool
+	EnableDDI            bool
 	RateLimitParallelism int
 }
 
@@ -45,6 +46,10 @@ func (c *Config) Client() (*ns1.Client, error) {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		httpClient.Transport = tr
+	}
+
+	if c.EnableDDI {
+		decos = append(decos, ns1.SetDDIAPI())
 	}
 
 	// If NS1_DEBUG is set, define custom Doer to log HTTP requests made by SDK

--- a/ns1/permissions.go
+++ b/ns1/permissions.go
@@ -118,6 +118,42 @@ func addPermsSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
 		Default:          false,
 		DiffSuppressFunc: suppressPermissionDiff,
 	}
+	s["security_manage_global_2fa"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["security_manage_active_directory"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["dhcp_manage_dhcp"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["dhcp_view_dhcp"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["ipam_manage_ipam"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["ipam_view_ipam"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
 	return s
 }
 
@@ -175,6 +211,18 @@ func permissionsToResourceData(d *schema.ResourceData, permissions account.Permi
 	d.Set("monitoring_manage_lists", permissions.Monitoring.ManageLists)
 	d.Set("monitoring_manage_jobs", permissions.Monitoring.ManageJobs)
 	d.Set("monitoring_view_jobs", permissions.Monitoring.ViewJobs)
+	if permissions.Security != nil {
+		d.Set("security_manage_global_2fa", permissions.Security.ManageGlobal2FA)
+		d.Set("security_manage_active_directory", permissions.Security.ManageActiveDirectory)
+	}
+	if permissions.DHCP != nil {
+		d.Set("dhcp_manage_dhcp", permissions.DHCP.ManageDHCP)
+		d.Set("dhcp_view_dhcp", permissions.DHCP.ViewDHCP)
+	}
+	if permissions.IPAM != nil {
+		d.Set("ipam_manage_ipam", permissions.IPAM.ManageIPAM)
+		d.Set("ipam_view_ipam", permissions.IPAM.ViewIPAM)
+	}
 }
 
 func resourceDataToPermissions(d *schema.ResourceData) account.PermissionsMap {
@@ -247,6 +295,42 @@ func resourceDataToPermissions(d *schema.ResourceData) account.PermissionsMap {
 	}
 	if v, ok := d.GetOk("monitoring_view_jobs"); ok {
 		p.Monitoring.ViewJobs = v.(bool)
+	}
+	if v, ok := d.GetOk("security_manage_global_2fa"); ok {
+		if p.Security == nil {
+			p.Security = &account.PermissionsSecurity{}
+		}
+		p.Security.ManageGlobal2FA = v.(bool)
+	}
+	if v, ok := d.GetOk("security_manage_active_directory"); ok {
+		if p.Security == nil {
+			p.Security = &account.PermissionsSecurity{}
+		}
+		p.Security.ManageActiveDirectory = v.(bool)
+	}
+	if v, ok := d.GetOk("dhcp_manage_dhcp"); ok {
+		if p.DHCP == nil {
+			p.DHCP = &account.PermissionsDHCP{}
+		}
+		p.DHCP.ManageDHCP = v.(bool)
+	}
+	if v, ok := d.GetOk("dhcp_view_dhcp"); ok {
+		if p.DHCP == nil {
+			p.DHCP = &account.PermissionsDHCP{}
+		}
+		p.DHCP.ViewDHCP = v.(bool)
+	}
+	if v, ok := d.GetOk("ipam_manage_ipam"); ok {
+		if p.IPAM == nil {
+			p.IPAM = &account.PermissionsIPAM{}
+		}
+		p.IPAM.ManageIPAM = v.(bool)
+	}
+	if v, ok := d.GetOk("ipam_view_ipam"); ok {
+		if p.IPAM == nil {
+			p.IPAM = &account.PermissionsIPAM{}
+		}
+		p.IPAM.ViewIPAM = v.(bool)
 	}
 	return p
 }

--- a/ns1/permissions_migrations.go
+++ b/ns1/permissions_migrations.go
@@ -1,0 +1,130 @@
+package ns1
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+func permissionInstanceStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	rawState["security_manage_global_2fa"] = false
+	rawState["security_manage_active_directory"] = false
+	rawState["dhcp_manage_dhcp"] = false
+	rawState["dhcp_view_dhcp"] = false
+	rawState["ipam_manage_ipam"] = false
+	rawState["ipam_view_ipam"] = false
+
+	return rawState, nil
+}
+
+func addPermsSchemaV0(s map[string]*schema.Schema) map[string]*schema.Schema {
+	s["dns_view_zones"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["dns_manage_zones"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["dns_zones_allow_by_default"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["dns_zones_deny"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	s["dns_zones_allow"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	s["data_push_to_datafeeds"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["data_manage_datasources"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["data_manage_datafeeds"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_manage_users"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_manage_payment_methods"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_manage_plan"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_manage_teams"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_manage_apikeys"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_manage_account_settings"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_view_activity_log"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["account_view_invoices"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["monitoring_manage_lists"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["monitoring_manage_jobs"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	s["monitoring_view_jobs"] = &schema.Schema{
+		Type:             schema.TypeBool,
+		Optional:         true,
+		Default:          false,
+		DiffSuppressFunc: suppressPermissionDiff,
+	}
+	return s
+}

--- a/ns1/provider.go
+++ b/ns1/provider.go
@@ -31,6 +31,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("NS1_IGNORE_SSL", nil),
 				Description: descriptions["ignore_ssl"],
 			},
+			"enable_ddi": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NS1_ENABLE_DDI", nil),
+				Description: descriptions["enable_ddi"],
+			},
 			"rate_limit_parallelism": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -79,6 +85,9 @@ func ns1Configure(d *schema.ResourceData) (interface{}, error) {
 	}
 	if v, ok := d.GetOk("ignore_ssl"); ok {
 		config.IgnoreSSL = v.(bool)
+	}
+	if v, ok := d.GetOk("enable_ddi"); ok {
+		config.EnableDDI = v.(bool)
 	}
 	if v, ok := d.GetOk("rate_limit_parallelism"); ok {
 		config.RateLimitParallelism = v.(int)

--- a/ns1/resource_apikey_migrations.go
+++ b/ns1/resource_apikey_migrations.go
@@ -1,0 +1,31 @@
+package ns1
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+func apikeyResourceV0() *schema.Resource {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"key": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"teams": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+	}
+
+	s = addPermsSchemaV0(s)
+
+	return &schema.Resource{
+		Schema: s,
+		Create: ApikeyCreate,
+		Read:   ApikeyRead,
+		Update: ApikeyUpdate,
+		Delete: ApikeyDelete,
+	}
+}

--- a/ns1/resource_team_migrations.go
+++ b/ns1/resource_team_migrations.go
@@ -1,0 +1,22 @@
+package ns1
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+func teamResourceV0() *schema.Resource {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+	}
+
+	s = addPermsSchemaV0(s)
+
+	return &schema.Resource{
+		Schema: s,
+		Create: TeamCreate,
+		Read:   TeamRead,
+		Update: TeamUpdate,
+		Delete: TeamDelete,
+	}
+}

--- a/ns1/resource_user_migrations.go
+++ b/ns1/resource_user_migrations.go
@@ -1,0 +1,41 @@
+package ns1
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+func userResourceV0() *schema.Resource {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"username": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"email": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"notify": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem:     schema.TypeBool,
+		},
+		"teams": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+	}
+
+	s = addPermsSchemaV0(s)
+
+	return &schema.Resource{
+		Schema: s,
+		Create: UserCreate,
+		Read:   UserRead,
+		Update: UserUpdate,
+		Delete: UserDelete,
+	}
+}

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_apikey.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_apikey.go
@@ -61,9 +61,23 @@ func (s *APIKeysService) Get(keyID string) (*account.APIKey, *http.Response, err
 //
 // NS1 API docs: https://ns1.com/api/#apikeys-put
 func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
-	req, err := s.client.NewRequest("PUT", "account/apikeys", &a)
-	if err != nil {
-		return nil, err
+	var (
+		req *http.Request
+		err error
+	)
+
+	// If this is DDI then the permissions need to be transformed to DDI-compatible permissions.
+	if s.client.DDI && a != nil {
+		ddiAPIKey := apiKeyToDDIAPIKey(a)
+		req, err = s.client.NewRequest("PUT", "account/apikeys", ddiAPIKey)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		req, err = s.client.NewRequest("PUT", "account/apikeys", a)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Update account fields with data from api(ensure consistent)
@@ -87,9 +101,23 @@ func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
 func (s *APIKeysService) Update(a *account.APIKey) (*http.Response, error) {
 	path := fmt.Sprintf("account/apikeys/%s", a.ID)
 
-	req, err := s.client.NewRequest("POST", path, &a)
-	if err != nil {
-		return nil, err
+	var (
+		req *http.Request
+		err error
+	)
+
+	// If this is DDI then the permissions need to be transformed to DDI-compatible permissions.
+	if s.client.DDI && a != nil {
+		ddiAPIKey := apiKeyToDDIAPIKey(a)
+		req, err = s.client.NewRequest("POST", path, ddiAPIKey)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		req, err = s.client.NewRequest("POST", path, a)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Update apikey fields with data from api(ensure consistent)
@@ -138,3 +166,40 @@ var (
 	// ErrKeyMissing bundles GET/POST/DELETE error.
 	ErrKeyMissing = errors.New("key does not exist")
 )
+
+func apiKeyToDDIAPIKey(k *account.APIKey) *ddiAPIKey {
+	ddiAPIKey := &ddiAPIKey{
+		ID:                k.ID,
+		Key:               k.Key,
+		LastAccess:        k.LastAccess,
+		Name:              k.Name,
+		TeamIDs:           k.TeamIDs,
+		IPWhitelist:       k.IPWhitelist,
+		IPWhitelistStrict: k.IPWhitelistStrict,
+		Permissions: ddiPermissionsMap{
+			DNS:  k.Permissions.DNS,
+			Data: k.Permissions.Data,
+			Account: permissionsDDIAccount{
+				ManageUsers:           k.Permissions.Account.ManageUsers,
+				ManageTeams:           k.Permissions.Account.ManageTeams,
+				ManageApikeys:         k.Permissions.Account.ManageApikeys,
+				ManageAccountSettings: k.Permissions.Account.ManageAccountSettings,
+				ViewActivityLog:       k.Permissions.Account.ViewActivityLog,
+			},
+		},
+	}
+
+	if k.Permissions.Security != nil {
+		ddiAPIKey.Permissions.Security = permissionsDDISecurity(*k.Permissions.Security)
+	}
+
+	if k.Permissions.DHCP != nil {
+		ddiAPIKey.Permissions.DHCP = *k.Permissions.DHCP
+	}
+
+	if k.Permissions.IPAM != nil {
+		ddiAPIKey.Permissions.IPAM = *k.Permissions.IPAM
+	}
+
+	return ddiAPIKey
+}

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	clientVersion = "2.0.0"
+	clientVersion = "2.2.0"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true
@@ -50,6 +50,9 @@ type Client struct {
 
 	// Whether the client should handle paginated responses automatically.
 	FollowPagination bool
+
+	// Enables permissions compatibility with the DDI API.
+	DDI bool
 
 	// From the excellent github-go client.
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
@@ -139,6 +142,11 @@ func SetRateLimitFunc(ratefunc func(rl RateLimit)) func(*Client) {
 // SetFollowPagination sets a Client instances' FollowPagination attribute.
 func SetFollowPagination(shouldFollow bool) func(*Client) {
 	return func(c *Client) { c.FollowPagination = shouldFollow }
+}
+
+// SetDDIAPI configures the client to use permissions compatible with the DDI API.
+func SetDDIAPI() func(*Client) {
+	return func(c *Client) { c.DDI = true }
 }
 
 // Do satisfies the Doer interface. resp will be nil if a non-HTTP error

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/ddi.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/ddi.go
@@ -1,0 +1,73 @@
+package rest
+
+import "gopkg.in/ns1/ns1-go.v2/rest/model/account"
+
+// ddiTeam wraps an NS1 /accounts/teams resource for DDI.
+// Used for internally mapping between DDI permissions to maintain backwards compatibility.
+type ddiTeam struct {
+	ID          string                `json:"id,omitempty"`
+	Name        string                `json:"name"`
+	Permissions ddiPermissionsMap     `json:"permissions"`
+	IPWhitelist []account.IPWhitelist `json:"ip_whitelist"`
+}
+
+// ddiUser wraps an NS1 /account/users resource for DDI.
+// Used for internally mapping between DDI permissions to maintain backwards compatibility.
+type ddiUser struct {
+	// Read-only fields
+	LastAccess float64 `json:"last_access"`
+
+	Name              string                       `json:"name"`
+	Username          string                       `json:"username"`
+	Email             string                       `json:"email"`
+	TeamIDs           []string                     `json:"teams"`
+	Notify            account.NotificationSettings `json:"notify"`
+	IPWhitelist       []string                     `json:"ip_whitelist"`
+	IPWhitelistStrict bool                         `json:"ip_whitelist_strict"`
+
+	Permissions ddiPermissionsMap `json:"permissions"`
+}
+
+// ddiAPIKey wraps an NS1 /account/apikeys resource for DDI specifically.
+// Used for internally mapping between DDI permissions to maintain backwards compatibility.
+type ddiAPIKey struct {
+	// Read-only fields
+	ID         string `json:"id,omitempty"`
+	Key        string `json:"key,omitempty"`
+	LastAccess int    `json:"last_access,omitempty"`
+
+	Name              string   `json:"name"`
+	TeamIDs           []string `json:"teams"`
+	IPWhitelist       []string `json:"ip_whitelist"`
+	IPWhitelistStrict bool     `json:"ip_whitelist_strict"`
+
+	Permissions ddiPermissionsMap `json:"permissions"`
+}
+
+// ddiPermissionsMap wraps a User's "permissions" attribute for DDI.
+// Used for internally mapping between DDI permissions to maintain backwards compatibility.
+type ddiPermissionsMap struct {
+	DNS      account.PermissionsDNS  `json:"dns"`
+	Data     account.PermissionsData `json:"data"`
+	Account  permissionsDDIAccount   `json:"account"`
+	Security permissionsDDISecurity  `json:"security"`
+	DHCP     account.PermissionsDHCP `json:"dhcp"`
+	IPAM     account.PermissionsIPAM `json:"ipam"`
+}
+
+// permissionsDDIAccount wraps a User's "permissions.account" attribute for DDI.
+// Used for internally mapping between DDI permissions to maintain backwards compatibility.
+type permissionsDDIAccount struct {
+	ManageUsers           bool `json:"manage_users"`
+	ManageTeams           bool `json:"manage_teams"`
+	ManageApikeys         bool `json:"manage_apikeys"`
+	ManageAccountSettings bool `json:"manage_account_settings"`
+	ViewActivityLog       bool `json:"view_activity_log"`
+}
+
+// permissionsDDISecurity wraps a User's "permissions.security" attribute for DDI.
+// Used for internally mapping between DDI permissions to maintain backwards compatibility.
+type permissionsDDISecurity struct {
+	ManageGlobal2FA       bool `json:"manage_global_2fa"`
+	ManageActiveDirectory bool `json:"manage_active_directory"`
+}

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/apikey.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/apikey.go
@@ -7,7 +7,9 @@ type APIKey struct {
 	Key        string `json:"key,omitempty"`
 	LastAccess int    `json:"last_access,omitempty"`
 
-	Name        string         `json:"name"`
-	TeamIDs     []string       `json:"teams"`
-	Permissions PermissionsMap `json:"permissions"`
+	Name              string         `json:"name"`
+	TeamIDs           []string       `json:"teams"`
+	Permissions       PermissionsMap `json:"permissions"`
+	IPWhitelist       []string       `json:"ip_whitelist"`
+	IPWhitelistStrict bool           `json:"ip_whitelist_strict"`
 }

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/permissions.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/permissions.go
@@ -6,6 +6,11 @@ type PermissionsMap struct {
 	Data       PermissionsData       `json:"data"`
 	Account    PermissionsAccount    `json:"account"`
 	Monitoring PermissionsMonitoring `json:"monitoring"`
+	Security   *PermissionsSecurity  `json:"security,omitempty"`
+
+	// DHCP and IPAM are only relevant for DDI and should not be provided in managed.
+	DHCP *PermissionsDHCP `json:"dhcp,omitempty"`
+	IPAM *PermissionsIPAM `json:"ipam,omitempty"`
 }
 
 // PermissionsDNS wraps a User's "permissions.dns" attribute
@@ -36,9 +41,30 @@ type PermissionsAccount struct {
 	ViewInvoices          bool `json:"view_invoices"`
 }
 
+// PermissionsSecurity wraps a User's "permissions.security" attribute.
+type PermissionsSecurity struct {
+	ManageGlobal2FA bool `json:"manage_global_2fa"`
+
+	// This field is only relevant for DDI and should not be set to true for managed.
+	ManageActiveDirectory bool `json:"manage_active_directory,omitempty"`
+}
+
 // PermissionsMonitoring wraps a User's "permissions.monitoring" attribute
+// Only relevant for the managed product.
 type PermissionsMonitoring struct {
 	ManageLists bool `json:"manage_lists"`
 	ManageJobs  bool `json:"manage_jobs"`
 	ViewJobs    bool `json:"view_jobs"`
+}
+
+// PermissionsDHCP wraps a User's "permissions.dhcp" attribute for DDI.
+type PermissionsDHCP struct {
+	ManageDHCP bool `json:"manage_dhcp"`
+	ViewDHCP   bool `json:"view_dhcp"`
+}
+
+// PermissionsIPAM wraps a User's "permissions.ipam" attribute for DDI.
+type PermissionsIPAM struct {
+	ManageIPAM bool `json:"manage_ipam"`
+	ViewIPAM   bool `json:"view_ipam"`
 }

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/team.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/team.go
@@ -5,4 +5,12 @@ type Team struct {
 	ID          string         `json:"id,omitempty"`
 	Name        string         `json:"name"`
 	Permissions PermissionsMap `json:"permissions"`
+	IPWhitelist []IPWhitelist  `json:"ip_whitelist"`
+}
+
+// IPWhitelist wraps the IP whitelist for Teams.
+type IPWhitelist struct {
+	ID     string   `json:"id,omitempty"`
+	Name   string   `json:"name"`
+	Values []string `json:"values"`
 }

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/user.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/model/account/user.go
@@ -4,16 +4,41 @@ package account
 type User struct {
 	// Read-only fields
 	LastAccess float64 `json:"last_access"`
+	Created    float64 `json:"created"`
 
-	Name        string               `json:"name"`
-	Username    string               `json:"username"`
-	Email       string               `json:"email"`
-	TeamIDs     []string             `json:"teams"`
-	Notify      NotificationSettings `json:"notify"`
-	Permissions PermissionsMap       `json:"permissions"`
+	Name                 string               `json:"name"`
+	Username             string               `json:"username"`
+	Email                string               `json:"email"`
+	TeamIDs              []string             `json:"teams"`
+	Notify               NotificationSettings `json:"notify"`
+	Permissions          PermissionsMap       `json:"permissions"`
+	IPWhitelist          []string             `json:"ip_whitelist"`
+	IPWhitelistStrict    bool                 `json:"ip_whitelist_strict"`
+	TwoFactorAuthEnabled bool                 `json:"2fa_enabled"`
+	InviteToken          string               `json:"invite_token,omitempty"`
+	SharedAuth           `json:"shared_auth"`
 }
 
 // NotificationSettings wraps a User's "notify" attribute
 type NotificationSettings struct {
 	Billing bool `json:"billing"`
+}
+
+// SharedAuth wraps the shared auth object on a User.
+type SharedAuth struct {
+	SAML `json:"saml"`
+}
+
+// SAML wraps the SAML object in SharedAuth.
+type SAML struct {
+	SSO bool `json:"sso"`
+	IDP `json:"idp"`
+}
+
+// IDP wraps the IDP object in SAML.
+type IDP struct {
+	UseMetadataURL *bool   `json:"use_metadata_url"`
+	MetadataURL    *string `json:"metadata_url"`
+	MetadataFile   *string `json:"metadata_file"`
+	Provider       *string `json:"provider"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -358,7 +358,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
-# gopkg.in/ns1/ns1-go.v2 v2.0.0-20191126161805-25b9eac84517
+# gopkg.in/ns1/ns1-go.v2 v2.2.0
 gopkg.in/ns1/ns1-go.v2/rest
 gopkg.in/ns1/ns1-go.v2/rest/model/account
 gopkg.in/ns1/ns1-go.v2/rest/model/data

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -40,6 +40,9 @@ The following arguments are supported:
 * `endpoint` - (Optional) NS1 API endpoint. For managed clients, this normally
   should not be set.
 * `ignore_ssl` - (Optional) This normally does not need to be set.
+* `enable_ddi` - (Optional) This sets the permission schema to a DDI-compatible schema. 
+Users of the managed SaaS product should not need to set this.
+Users of DDI should set this to true if managing teams, users, or API keys through this provider.
 * `rate_limit_parallelism` - (Optional) Integer for parallelism amount
   (terraform's default is 10). If set, uses an alternate strategy to handle
   rate limiting from the NS1 API. Give this a try if you are processing a large

--- a/website/docs/r/apikey.html.markdown
+++ b/website/docs/r/apikey.html.markdown
@@ -21,6 +21,9 @@ resource "ns1_apikey" "example" {
   name  = "Example key"
   teams = ["${ns1_team.example.id}"]
 
+  # Optional IP whitelist
+  ip_whitelist = ["1.1.1.1","2.2.2.2"]
+
   # Configure permissions 
   dns_view_zones       = false
   account_manage_users = false
@@ -46,6 +49,8 @@ The following arguments are supported:
 * `name` - (Required) The free form name of the apikey.
 * `key` - (Required) The apikeys authentication token.
 * `teams` - (Optional) The teams that the apikey belongs to.
+* `ip_whitelist` - (Optional) The IP addresses to whitelist for this key.
+* `ip_whitelist_strict` - (Optional) Sets exclusivity on this IP whitelist.
 * `dns_view_zones` - (Optional) Whether the apikey can view the accounts zones.
 * `dns_manage_zones` - (Optional) Whether the apikey can modify the accounts zones.
 * `dns_zones_allow_by_default` - (Optional) If true, enable the `dns_zones_allow` list, otherwise enable the `dns_zones_deny` list.
@@ -65,6 +70,17 @@ The following arguments are supported:
 * `monitoring_manage_lists` - (Optional) Whether the apikey can modify notification lists.
 * `monitoring_manage_jobs` - (Optional) Whether the apikey can modify monitoring jobs.
 * `monitoring_view_jobs` - (Optional) Whether the apikey can view monitoring jobs.
+* `security_manage_global_2fa` - (Optional) Whether the apikey can manage global two factor authentication.
+* `security_manage_active_directory` - (Optional) Whether the apikey can manage global active directory.
+Only relevant for the DDI product.
+* `dhcp_manage_dhcp` - (Optional) Whether the apikey can manage DHCP.
+Only relevant for the DDI product.
+* `dhcp_view_dhcp` - (Optional) Whether the apikey can view DHCP.
+Only relevant for the DDI product.
+* `ipam_manage_ipam` - (Optional) Whether the apikey can manage IPAM.
+Only relevant for the DDI product.
+* `ipam_view_ipam` - (Optional) Whether the apikey can view IPAM.
+Only relevant for the DDI product.
 
 ## Attributes Reference
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -18,6 +18,17 @@ teams. The credentials used must have the `manage_teams` permission set.
 resource "ns1_team" "example" {
   name = "Example team"
 
+    
+  # Optional IP whitelists
+  ip_whitelist {
+    name = "whitelist-1"
+    values = ["1.1.1.1", "2.2.2.2"]
+  }
+  ip_whitelist {
+    name = "whitelist-2"
+    values = ["3.3.3.3", "4.4.4.4"]
+  }
+
   # Configure permissions
   dns_view_zones       = false
   account_manage_users = false
@@ -29,6 +40,7 @@ resource "ns1_team" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The free form name of the team.
+* `ip_whitelist` - (Optional) The IP addresses to whitelist for this key.
 * `dns_view_zones` - (Optional) Whether the team can view the accounts zones.
 * `dns_manage_zones` - (Optional) Whether the team can modify the accounts zones.
 * `dns_zones_allow_by_default` - (Optional) If true, enable the `dns_zones_allow` list, otherwise enable the `dns_zones_deny` list.
@@ -48,6 +60,17 @@ The following arguments are supported:
 * `monitoring_manage_lists` - (Optional) Whether the team can modify notification lists.
 * `monitoring_manage_jobs` - (Optional) Whether the team can modify monitoring jobs.
 * `monitoring_view_jobs` - (Optional) Whether the team can view monitoring jobs.
+* `security_manage_global_2fa` - (Optional) Whether the team can manage global two factor authentication.
+* `security_manage_active_directory` - (Optional) Whether the team can manage global active directory.
+Only relevant for the DDI product.
+* `dhcp_manage_dhcp` - (Optional) Whether the team can manage DHCP.
+Only relevant for the DDI product.
+* `dhcp_view_dhcp` - (Optional) Whether the team can view DHCP.
+Only relevant for the DDI product.
+* `ipam_manage_ipam` - (Optional) Whether the team can manage IPAM.
+Only relevant for the DDI product.
+* `ipam_view_ipam` - (Optional) Whether the team can view IPAM.
+Only relevant for the DDI product.
 
 ## Attributes Reference
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -18,6 +18,9 @@ The credentials used must have the `manage_users` permission set.
 resource "ns1_team" "example" {
   name = "Example team"
 
+  # Optional IP whitelist
+  ip_whitelist = ["1.1.1.1","2.2.2.2"]
+
   dns_view_zones       = false
   account_manage_users = false
 }
@@ -51,6 +54,8 @@ The following arguments are supported:
 * `email` - (Required) The email address of the user.
 * `notify` - (Required) Whether or not to notify the user of specified events. Only `billing` is available currently.
 * `teams` - (Required) The teams that the user belongs to.
+* `ip_whitelist` - (Optional) The IP addresses to whitelist for this key.
+* `ip_whitelist_strict` - (Optional) Sets exclusivity on this IP whitelist.
 * `dns_view_zones` - (Optional) Whether the user can view the accounts zones.
 * `dns_manage_zones` - (Optional) Whether the user can modify the accounts zones.
 * `dns_zones_allow_by_default` - (Optional) If true, enable the `dns_zones_allow` list, otherwise enable the `dns_zones_deny` list.
@@ -70,6 +75,15 @@ The following arguments are supported:
 * `monitoring_manage_lists` - (Optional) Whether the user can modify notification lists.
 * `monitoring_manage_jobs` - (Optional) Whether the user can modify monitoring jobs.
 * `monitoring_view_jobs` - (Optional) Whether the user can view monitoring jobs.
+* `security_manage_global_2fa` - (Optional) Whether the user can manage global two factor authentication.
+* `security_manage_active_directory` - (Optional) Whether the user can manage global active directory.
+Only relevant for the DDI product.
+* `dhcp_manage_dhcp` - (Optional) Whether the user can manage DHCP.
+Only relevant for the DDI product.
+* `dhcp_view_dhcp` - (Optional) Whether the user can view DHCP.
+Only relevant for the DDI product.
+* `ipam_manage_ipam` - (Optional) Whether the user can manage IPAM.
+Only relevant for the DDI product.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Would like to get some thoughts on the state migration. There didn't seem to be a way to add DDI permissions transparently to users of SaaS without a migration, because the DDI permissions still get defaulted to false, so if you were a SaaS user and upgraded TF, you would see a diff on the new permissions being added and set to false (even though they weren't actually propagating to the API). Doesn't seem like a huge deal, but it seemed confusing to me, so I added this migration to properly handle it. Now if a user upgrades to this version, they shouldn't see a diff on their permissions, but it also might be overkill.