### PR TITLE
Update Documentation For IPv4 Only Fields

### DIFF
--- a/website/docs/d/zone.html.markdown
+++ b/website/docs/d/zone.html.markdown
@@ -30,8 +30,9 @@ data "ns1_zone" "example" {
 In addition to the argument above, the following are exported:
 
 * `link` - The linked target zone.
-* `primary` - The primary ip.
-* `additional_primaries` - List of additional IPs for the primary zone.
+* `primary` - The primary zones' IPv4 address.
+* `additional_primaries` - List of additional IPv4 addresses for the primary
+  zone.
 * `ttl` - The SOA TTL.
 * `refresh` - The SOA Refresh.
 * `retry` - The SOA Retry.

--- a/website/docs/r/zone.html.markdown
+++ b/website/docs/r/zone.html.markdown
@@ -69,9 +69,9 @@ The following arguments are supported:
 
 * `zone` - (Required) The domain name of the zone.
 * `link` - (Optional) The target zone(domain name) to link to.
-* `primary` - (Optional) The primary zones' IP. This makes the zone a
+* `primary` - (Optional) The primary zones' IPv4 address. This makes the zone a
   secondary. Conflicts with `secondaries`.
-* `additional_primaries` - (Optional) List of additional IPs for the primary
+* `additional_primaries` - (Optional) List of additional IPv4 addresses for the primary
   zone. Conflicts with `secondaries`.
 * `ttl` - (Optional/Computed) The SOA TTL.
 * `refresh` - (Optional/Computed) The SOA Refresh. Conflicts with `primary` and


### PR DESCRIPTION
Documentation update to clarify `primary` and `additional_primaries` fields only support IPv4 addresses.  Closes #106. 