### PR TITLE
Fixes for the resource_record to better error reporting and type conversion

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -460,7 +460,7 @@ func RecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	if _, err := client.Records.Update(r); err != nil {
 		return err
 	}
-	return RecordRead(d, meta)
+	return recordToResourceData(d, r)
 }
 
 func recordStateFunc(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -203,7 +203,7 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 
 	// top level meta works but nested meta doesn't
 	if r.Meta != nil {
-		err := d.Set("meta", structs.Map(r.Meta))
+		err := d.Set("meta", recordMapValueToString(structs.Map(r.Meta)))
 		if err != nil {
 			return fmt.Errorf("[DEBUG] Error setting meta for: %s, error: %#v", r.Domain, err)
 		}
@@ -223,7 +223,7 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 				m["disabled"] = true
 			}
 			if f.Config != nil {
-				m["config"] = f.Config
+				m["config"] = recordMapValueToString(f.Config)
 			}
 			filters[i] = m
 		}
@@ -265,6 +265,24 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 		}
 	}
 	return nil
+}
+
+func recordMapValueToString(configMap map[string]interface{}) map[string]interface{} {
+	config := make(map[string]interface{})
+	for configKey, configValue := range configMap {
+		switch configValue.(type) {
+		case bool:
+			if configValue.(bool) {
+				config[configKey] = "1"
+			} else {
+				config[configKey] = "0"
+			}
+			break
+		default:
+			config[configKey] = configValue
+		}
+	}
+	return config
 }
 
 func answerToMap(a dns.Answer) map[string]interface{} {

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -421,7 +421,7 @@ func RecordCreate(d *schema.ResourceData, meta interface{}) error {
 	if _, err := client.Records.Create(r); err != nil {
 		return err
 	}
-	return RecordRead(d, meta)
+	return recordToResourceData(d, r)
 }
 
 // RecordRead reads the DNS record from ns1

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -391,7 +391,7 @@ func RecordCreate(d *schema.ResourceData, meta interface{}) error {
 	if _, err := client.Records.Create(r); err != nil {
 		return err
 	}
-	return recordToResourceData(d, r)
+	return RecordRead(d, meta)
 }
 
 // RecordRead reads the DNS record from ns1
@@ -430,7 +430,7 @@ func RecordUpdate(d *schema.ResourceData, meta interface{}) error {
 	if _, err := client.Records.Update(r); err != nil {
 		return err
 	}
-	return recordToResourceData(d, r)
+	return RecordRead(d, meta)
 }
 
 func recordStateFunc(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -209,7 +209,10 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 		}
 	}
 	if r.UseClientSubnet != nil {
-		d.Set("use_client_subnet", *r.UseClientSubnet)
+		err := d.Set("use_client_subnet", *r.UseClientSubnet)
+		if err != nil {
+			return fmt.Errorf("[DEBUG] Error setting use_client_subnet for: %s, error: %#v", r.Domain, err)
+		}
 	}
 	if len(r.Filters) > 0 {
 		filters := make([]map[string]interface{}, len(r.Filters))

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -203,7 +203,10 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 
 	// top level meta works but nested meta doesn't
 	if r.Meta != nil {
-		d.Set("meta", structs.Map(r.Meta))
+		err := d.Set("meta", structs.Map(r.Meta))
+		if err != nil {
+			return fmt.Errorf("[DEBUG] Error setting meta for: %s, error: %#v", r.Domain, err)
+		}
 	}
 	if r.UseClientSubnet != nil {
 		d.Set("use_client_subnet", *r.UseClientSubnet)

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -195,7 +195,10 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 	d.Set("type", r.Type)
 	d.Set("ttl", r.TTL)
 	if r.Link != "" {
-		d.Set("link", r.Link)
+		err := d.Set("link", r.Link)
+		if err != nil {
+			return fmt.Errorf("[DEBUG] Error setting link for: %s, error: %#v", r.Domain, err)
+		}
 	}
 
 	// top level meta works but nested meta doesn't

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -218,7 +218,10 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 			}
 			filters[i] = m
 		}
-		d.Set("filters", filters)
+		err := d.Set("filters", filters)
+		if err != nil {
+			return fmt.Errorf("[DEBUG] Error setting filters for: %s, error: %#v", r.Domain, err)
+		}
 	}
 	if len(r.Answers) > 0 {
 		ans := make([]map[string]interface{}, 0)


### PR DESCRIPTION
We had some record receiving an error message from the provider reporting inconsistencies in the data read. This also prevented us from updating/modifying some information in that new record. No clear idea as to why the provider was working for another identical record in another zone, the main difference being the networks enabled at the zone level.

I thus went ahead and wrote a few fixes for this:
- Use the actual read method when creating/updating to avoid content inconsistency between what we say should be there and what is actually there after the create/update (as recommended by terraform)
- Add error reporting for the `d.Set` calls as to be aware of when they fail, instead of just ignoring it
- Process the maps read from the API that are expected to be `map[string]string` to convert booleans into `"1"`/`"0"`

Example or `Error` shown by the added reports that lead to writing the method to process the maps:
```
Error: [DEBUG] Error setting filters for: <some_record>, error: &errors.errorString{s:"filters.3.config.eliminate: '' expected type 'string', got unconvertible type 'bool'"}
```