### PR TITLE
fix meta diff suppress up

### DIFF
--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -512,15 +512,16 @@ func metaDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+// suppress a detected diff if it reflects an unchanged boolean value
 func metaDiffSuppressUp(k, old, new string, _ *schema.ResourceData) bool {
 	if strings.HasSuffix(k, "up") {
 		newB, err := strconv.ParseBool(new)
 		if err != nil {
-			return new == old
+			return false
 		}
 		oldB, err := strconv.ParseBool(old)
 		if err != nil {
-			return new == old
+			return false
 		}
 		if newB == oldB {
 			return true

--- a/ns1/resource_record.go
+++ b/ns1/resource_record.go
@@ -514,8 +514,14 @@ func metaDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 
 func metaDiffSuppressUp(k, old, new string, _ *schema.ResourceData) bool {
 	if strings.HasSuffix(k, "up") {
-		newB, _ := strconv.ParseBool(new)
-		oldB, _ := strconv.ParseBool(old)
+		newB, err := strconv.ParseBool(new)
+		if err != nil {
+			return new == old
+		}
+		oldB, err := strconv.ParseBool(old)
+		if err != nil {
+			return new == old
+		}
 		if newB == oldB {
 			return true
 		}


### PR DESCRIPTION
a record's answer's meta's "up" field can be a feed pointer, recently
added diff suppression always evaluated these as "unchanged"

handle this case, and add a test exercising this kind of record answer
meta up