### PR TITLE
Update username validation

### DIFF
--- a/ns1/resource_user.go
+++ b/ns1/resource_user.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/ns1/ns1-go.v2/rest/model/account"
 )
 
-var usernameRegex = regexp.MustCompile(`^([a-zA-Z0-9_+.@]+)$`)
+var usernameRegex = regexp.MustCompile(`^([-a-zA-Z0-9_@%.+]{3,64})$`)
 
 func userResource() *schema.Resource {
 	s := map[string]*schema.Schema{

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -497,6 +497,16 @@ func TestValidateUsername(t *testing.T) {
 			"inv@l!d_us3r",
 			1,
 		},
+		{
+			"invalid - too short (<3)",
+			"a",
+			"1",
+		},
+		{
+			"invalid - too long (>64)",
+			".................................................................",
+			"1",
+		},
 	}
 
 	for _, tt := range tests {

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -483,12 +483,17 @@ func TestValidateUsername(t *testing.T) {
 			0,
 		},
 		{
-			"invalid - dash",
-			"inv4lid-user",
-			1,
+			"valid - dash",
+			"v4lid-user",
+			0,
 		},
 		{
-			"invalid - punctuation",
+			"valid - punctuation",
+			"%v.4.l.i.d_u.s.3.r.+name@%",
+			"0",
+		},
+		{
+			"invalid - punctuation (exclamation)",
 			"inv@l!d_us3r",
 			1,
 		},

--- a/ns1/resource_user_test.go
+++ b/ns1/resource_user_test.go
@@ -490,7 +490,7 @@ func TestValidateUsername(t *testing.T) {
 		{
 			"valid - punctuation",
 			"%v.4.l.i.d_u.s.3.r.+name@%",
-			"0",
+			0,
 		},
 		{
 			"invalid - punctuation (exclamation)",
@@ -500,12 +500,12 @@ func TestValidateUsername(t *testing.T) {
 		{
 			"invalid - too short (<3)",
 			"a",
-			"1",
+			1,
 		},
 		{
 			"invalid - too long (>64)",
 			".................................................................",
-			"1",
+			1,
 		},
 	}
 


### PR DESCRIPTION
NS1's API will begin to accept usernames that contain `%` and `-` so the TF provider validation must be updated to match the API.